### PR TITLE
Add support for multiple eth addresses on exits

### DIFF
--- a/rita_client/src/rita_loop/mod.rs
+++ b/rita_client/src/rita_loop/mod.rs
@@ -171,9 +171,7 @@ fn check_for_gateway_client_billing_corner_case() {
                 // wg_key excluded due to multihomed exits having a different one
                 let current_ip = get_selected_exit_ip(current_exit.clone())
                     .expect("If registered, there should be an exit ip here");
-                if neigh.identity.global.mesh_ip == current_ip
-                    && neigh.identity.global.eth_address == exit.eth_address
-                {
+                if neigh.identity.global.mesh_ip == current_ip {
                     info!("We are a gateway client");
                     set_gateway_client(true);
                     return;

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -39,13 +39,17 @@ pub struct ExitServer {
     #[serde(default = "dummy_root_ip")]
     pub root_ip: IpAddr,
 
+    /// Can be removed once all routers on b20
     /// Subnet for backwards compatilibity
     #[serde(default)]
     pub subnet: Option<IpNetwork>,
 
+    /// Can be removed once all routers support multiple eth addresses
     /// eth address of this exit cluster
-    pub eth_address: Address,
+    pub eth_address: Option<Address>,
 
+    /// this is needed along with root ip to make an initial query to an exit for its list
+    /// This is the common wg key that all exits share
     /// wg public key used for wg_exit by this cluster
     /// each exit has a distinct wg key used for peer
     /// to peer tunnels and to identify it in logs


### PR DESCRIPTION
We pass in the correct parameters to query_exit_debts that we receive from the exit list. This sets up debt keeper with the correct exit identity and thus triggers payment controller to pay to the correct eth address