### PR TITLE
Update exit checkin to send a list of registered wgkey

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -716,6 +716,8 @@ pub struct OperatorExitCheckinMessage {
     pub pass: String,
     /// This is to keep track of the rita exit uptime for debugging purposes
     pub exit_uptime: Duration,
+    /// A list of registered wg keys that ops can use to display routers to be registered
+    pub registered_keys: Option<Vec<WgKey>>,
     /// Number of users online
     pub users_online: Option<u32>,
 }

--- a/rita_exit/src/operator_update/update_loop.rs
+++ b/rita_exit/src/operator_update/update_loop.rs
@@ -8,10 +8,12 @@ use std::time::{Duration, Instant};
 /// This function spawns a thread soley responsible for performing the operator update
 pub fn start_operator_update_loop() {
     let mut last_restart = Instant::now();
+    let rita_started = Instant::now();
     // outer thread is a watchdog inner thread is the runner
     thread::spawn(move || {
         // this will always be an error, so it's really just a loop statement
         // with some fancy destructuring
+
         while let Err(e) = {
             thread::spawn(move || loop {
                 let start = Instant::now();
@@ -20,7 +22,7 @@ pub fn start_operator_update_loop() {
                 let runner = AsyncSystem::new();
                 runner.block_on(async move {
                     // Check in with Operator
-                    operator_update().await;
+                    operator_update(rita_started).await;
                 });
 
                 info!(


### PR DESCRIPTION
The exit checkin now sends a list of WgKey it retrieves from the database during exit checkin. Ops can use this to display more accurately whether a router is registered or not. The key list is stored in a cache that is updated every 10 mins. This ensures we dont spam the database with request every 60secs and the database isnt dynamic enough for the extra wait time to be an issue