### PR TITLE
Generate test config file from function instead of file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ name = "test_runner"
 version = "0.1.0"
 dependencies = [
  "actix-rt",
+ "althea_kernel_interface",
  "awc",
  "ctrlc",
  "docopt",

--- a/integration_tests/src/setup_utils/database.rs
+++ b/integration_tests/src/setup_utils/database.rs
@@ -16,7 +16,7 @@ pub fn start_postgres() {
     const POSTGRES_BIN: &str = "/usr/lib/postgresql/15/bin/postgres";
     const INITDB_BIN: &str = "/usr/lib/postgresql/15/bin/initdb";
     // for this test script
-    const DB_URL_LOCAL: &str = "postgres://postgres@localhost/test";
+    const DB_URL_LOCAL: &str = "postgres://postgres@127.0.0.1/test";
     // for the rita exit instances
     const POSTGRES_DATABASE_LOCATION: &str = "/var/lib/postgresql/data";
     let migration_directory = Path::new("/althea_rs/exit_db/migrations/");

--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -15,3 +15,4 @@ ctrlc = {version = "3.2.1", features = ["termination"]}
 awc = "3.1"
 actix-rt = "2.8"
 integration_tests = {path = "../integration_tests"}
+althea_kernel_interface = { path = "../althea_kernel_interface" }

--- a/test_runner/src/main.rs
+++ b/test_runner/src/main.rs
@@ -1,6 +1,7 @@
 use integration_tests::debts::run_debts_test;
 /// Binary crate for actually running the integration tests
 use integration_tests::five_nodes::run_five_node_test_scenario;
+use integration_tests::utils::{generate_config_file, CONFIG_FILE_PATH};
 use integration_tests::{
     payments_althea::run_althea_payments_test_scenario,
     payments_eth::run_eth_payments_test_scenario, utils::set_sigterm,
@@ -24,6 +25,9 @@ async fn main() {
 
     info!("Starting the Rita test runner");
     println!("info above?");
+
+    let conf = generate_config_file(CONFIG_FILE_PATH.to_string());
+    info!("Generating rita config file: {:?}", conf);
 
     let test_type = env::var("TEST_TYPE");
     info!("Starting tests with {:?}", test_type);


### PR DESCRIPTION
In order to reduce the amount of files floating around, the example template used to generate rita settings can be moved to a function in the test runner, which comes with the bonus of being importable in other repos. test.toml must stay while the legacy integration test remains.