### PR TITLE
Use EVM version "paris" when compiling contracts

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -31,8 +31,9 @@ module.exports = {
     version: "0.8.21",
     settings: {
       optimizer: {
-        enabled: true
-      }
+        enabled: true,
+      },
+      evmVersion: "paris"
     }
   },
   networks: {


### PR DESCRIPTION
The updated version of Solidity (0.8.20+) comes with an additional opcode (PUSH0) supported by the "shanghai" version of the EVM. Althea-L1 does not support this opcode and so we must specify an older version to target. "paris" has been chosen since Althea-L1 is compatible as of the merge.