### PR TITLE
Refactor UsageTracker

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -622,7 +622,7 @@ pub struct OperatorUpdateMessage {
     pub operator_action: Option<OperatorAction>,
     /// String that holds the download link to the latest firmware release
     /// When a user hits 'update router', it updates to this version
-    /// to be removed once all routesr are updated to >= beta 19 rc9
+    /// to be removed once all routers are updated to >= beta 19 rc9
     pub local_update_instruction: Option<UpdateTypeLegacy>,
     /// String that holds the download link to the latest firmware release
     /// When a user hits 'update router', it updates to this version
@@ -754,6 +754,12 @@ pub struct OperatorCheckinMessage {
     /// saved usage hour is the same as the ops last seen, we send no data here as we are up
     /// to date. Data sent through here gets added to a database entry for each device.
     pub user_bandwidth_usage_v2: Option<UsageTrackerTransfer>,
+    /// Current client data usage in mbps computed as the last input to the usage tracker
+    /// so an average of around 5-10 seconds
+    pub client_mbps: Option<u64>,
+    /// Curent relay data usage in mbps, coputed as the last input to the usage tracker
+    /// so an average of around 5-10 seconds
+    pub relay_mbps: Option<u64>,
     /// This is to keep track of the rita client uptime for debugging purposes
     /// In the event something whacko happens, serde will magically derive def-
     /// fault value.

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -1,5 +1,5 @@
 use crate::{contact_info::ContactType, wg_key::WgKey, BillingDetails, InstallationDetails};
-use crate::{ClientExtender, UsageTracker, WifiDevice};
+use crate::{ClientExtender, UsageTrackerFlat, UsageTrackerTransfer, WifiDevice};
 use arrayvec::ArrayString;
 use babel_monitor::structs::Neighbor;
 use babel_monitor::structs::Route;
@@ -335,7 +335,7 @@ pub struct LightClientLocalIdentity {
 /// This represents a generic payment that may be to or from us
 /// it contains a txid from a published transaction
 /// that should be validated against the blockchain
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PaymentTx {
     pub to: Identity,
     pub from: Identity,
@@ -353,7 +353,7 @@ impl Hash for PaymentTx {
 
 /// This represents a generic payment that may be to or from us, it does not contain a txid meaning it is
 /// unpublished
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct UnpublishedPaymentTx {
     pub to: Identity,
     pub from: Identity,
@@ -747,11 +747,13 @@ pub struct OperatorCheckinMessage {
     /// This is a user set bandwidth limit value, it will cap the users download
     /// and upload to the provided value of their choosing. Denoted in mbps
     pub user_bandwidth_limit: Option<usize>,
+    /// Legacy bandwidth usage from pre beta 20 routers, one of the two will be None
+    pub user_bandwidth_usage: Option<UsageTrackerFlat>,
     /// Details of both the Client and Relay bandwidth usage over a given period determined
     /// by the ops_last_seen_usage_hour in OperatorUpdateMessage. When the device's last
     /// saved usage hour is the same as the ops last seen, we send no data here as we are up
     /// to date. Data sent through here gets added to a database entry for each device.
-    pub user_bandwidth_usage: Option<UsageTracker>,
+    pub user_bandwidth_usage_v2: Option<UsageTrackerTransfer>,
     /// This is to keep track of the rita client uptime for debugging purposes
     /// In the event something whacko happens, serde will magically derive def-
     /// fault value.

--- a/integration_tests/src/setup_utils/database.rs
+++ b/integration_tests/src/setup_utils/database.rs
@@ -13,8 +13,8 @@ use std::{
 /// Starts the exit postgres instance in the native system namespace, TODO insert plumbing so that exits can reach it
 pub fn start_postgres() {
     const POSTGRES_USER: &str = "postgres";
-    const POSTGRES_BIN: &str = "/usr/lib/postgresql/15/bin/postgres";
-    const INITDB_BIN: &str = "/usr/lib/postgresql/15/bin/initdb";
+    const POSTGRES_BIN: &str = "/usr/lib/postgresql/16/bin/postgres";
+    const INITDB_BIN: &str = "/usr/lib/postgresql/16/bin/initdb";
     // for this test script
     const DB_URL_LOCAL: &str = "postgres://postgres@127.0.0.1/test";
     // for the rita exit instances

--- a/legacy_integration_tests/container/Dockerfile
+++ b/legacy_integration_tests/container/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get install -y python3-termcolor python3-toml python3-networkx python3-m
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN PATH=$PATH:$HOME/.cargo/bin cargo install diesel_cli --force
 ENV POSTGRES_USER=postgres
-ENV POSTGRES_BIN=/usr/lib/postgresql/15/bin/postgres
-ENV INITDB_BIN=/usr/lib/postgresql/15/bin/initdb
+ENV POSTGRES_BIN=/usr/lib/postgresql/16/bin/postgres
+ENV INITDB_BIN=/usr/lib/postgresql/16/bin/initdb
 ARG NODES
 ENV SPEEDTEST_THROUGHPUT=$SPEEDTEST_THROUGHPUT
 ENV SPEEDTEST_DURATION=$SPEEDTEST_DURATION

--- a/rita_client/src/dashboard/usage.rs
+++ b/rita_client/src/dashboard/usage.rs
@@ -1,6 +1,6 @@
 use actix_web_async::{HttpRequest, HttpResponse};
 use rita_common::usage_tracker::get_usage_data;
-use rita_common::usage_tracker::UsageType;
+use rita_common::usage_tracker::structs::UsageType;
 
 pub async fn get_client_usage(_req: HttpRequest) -> HttpResponse {
     trace!("/usage/client hit");

--- a/rita_client/src/exit_manager/exit_switcher.rs
+++ b/rita_client/src/exit_manager/exit_switcher.rs
@@ -832,7 +832,7 @@ mod tests {
                     u16::MAX,
                     tracking_exit,
                     u16::MAX,
-                     best_exit,
+                    best_exit,
                     400
                 ),
                 &mut vec,

--- a/rita_client/src/operator_update/mod.rs
+++ b/rita_client/src/operator_update/mod.rs
@@ -20,8 +20,8 @@ use num256::Uint256;
 use rita_common::rita_loop::is_gateway;
 use rita_common::tunnel_manager::neighbor_status::get_neighbor_status;
 use rita_common::tunnel_manager::shaping::flag_reset_shaper;
-use rita_common::usage_tracker::structs::UsageType::{Client, Relay};
-use rita_common::usage_tracker::{get_current_hour, get_usage_data_map};
+use rita_common::usage_tracker::structs::UsageType::{self, Client, Relay};
+use rita_common::usage_tracker::{get_current_hour, get_current_throughput, get_usage_data_map};
 use rita_common::utils::option_convert;
 use rita_common::DROPBEAR_AUTHORIZED_KEYS;
 use rita_common::KI;
@@ -161,6 +161,8 @@ pub async fn operator_update(
             rita_uptime: RITA_UPTIME.elapsed(),
             user_bandwidth_usage: None,
             user_bandwidth_usage_v2: prepare_usage_data_for_upload(ops_last_seen_usage_hour)?,
+            client_mbps: get_current_throughput(UsageType::Client),
+            relay_mbps: get_current_throughput(UsageType::Relay),
         })
         .await;
 

--- a/rita_client/src/operator_update/update_loop.rs
+++ b/rita_client/src/operator_update/update_loop.rs
@@ -43,7 +43,8 @@ pub fn start_operator_update_loop() {
                                 wait_unti_next_update =
                                     max(wait_unti_next_update / 2, TARGET_UPDATE_FREQUENCY);
                             }
-                            Err(()) => {
+                            Err(e) => {
+                                error!("Ops checkin failed with {:?}!", e);
                                 // failed checkin, backoff with a random multiplier the goal of random backoff
                                 // is to prevent collisions
                                 wait_unti_next_update = min(

--- a/rita_client/src/traffic_watcher/mod.rs
+++ b/rita_client/src/traffic_watcher/mod.rs
@@ -32,9 +32,9 @@ use num_traits::identities::Zero;
 use rita_common::debt_keeper::{
     traffic_replace, traffic_update, wgkey_insensitive_traffic_update, Traffic,
 };
+use rita_common::usage_tracker::structs::UsageType;
 use rita_common::usage_tracker::update_usage_data;
 use rita_common::usage_tracker::UpdateUsage;
-use rita_common::usage_tracker::UsageType;
 use rita_common::KI;
 use std::collections::HashMap;
 use std::net::IpAddr;

--- a/rita_common/src/network_endpoints/mod.rs
+++ b/rita_common/src/network_endpoints/mod.rs
@@ -37,7 +37,7 @@ pub async fn make_payments_v2(item: Json<HashSet<PaymentTx>>) -> HttpResponse {
     let mut build_err = String::new();
     for pmt in pmt_list {
         let ts = ToValidate {
-            payment: pmt.clone(),
+            payment: pmt,
             received: Instant::now(),
             checked: false,
         };

--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -311,7 +311,7 @@ async fn make_althea_payment(
     // setup tx hash
     let pmt = pmt.publish(Uint256::from_str_radix(&transaction.txhash, 16).unwrap());
 
-    send_make_payment_endpoints(pmt.clone(), network_settings, None, Some(cosmos_node_grpc)).await;
+    send_make_payment_endpoints(pmt, network_settings, None, Some(cosmos_node_grpc)).await;
 
     // place this payment in the validation queue to handle later.
     let ts = ToValidate {
@@ -390,7 +390,7 @@ async fn make_xdai_payment(
     // add published txid to submission
     let pmt = pmt.publish(tx_id);
 
-    send_make_payment_endpoints(pmt.clone(), network_settings, Some(full_node), None).await;
+    send_make_payment_endpoints(pmt, network_settings, Some(full_node), None).await;
 
     // place this payment in the validation queue to handle later.
     let ts = ToValidate {
@@ -470,7 +470,7 @@ async fn send_make_payment_endpoints(
     // Get all txids to this client. Temporary add new payment to a copy of a list to send up to endpoint
     // this pmt is actually recorded in memory after validator confirms it
     let mut txid_history = get_payment_txids(pmt.to);
-    txid_history.insert(pmt.clone());
+    txid_history.insert(pmt);
 
     let actix_client = awc::Client::new();
     let neigh_ack = actix_client
@@ -485,7 +485,7 @@ async fn send_make_payment_endpoints(
 
     let resend_info = ResendInfo {
         neigh_url: neighbor_url.clone(),
-        pmt: pmt.clone(),
+        pmt,
         attempt: 0u8,
     };
 

--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -290,7 +290,7 @@ fn remove(msg: Remove) {
     // store successful transactions so that they can't be played back to us, at least
     // during this session
     if msg.success {
-        add_successful_tx(msg.tx.payment.clone());
+        add_successful_tx(msg.tx.payment);
     }
     if was_present {
         info!("Transaction {} was removed", msg.tx);
@@ -615,7 +615,7 @@ fn handle_tx_messaging_xdai(
 ) {
     let from_address = ts.payment.from.eth_address;
     let amount = ts.payment.amount;
-    let pmt = ts.payment.clone();
+    let pmt = ts.payment;
     let our_address = settings::get_rita_common()
         .payment
         .eth_address
@@ -709,7 +709,7 @@ fn handle_tx_messaging_xdai(
             );
 
             // update the usage tracker with the details of this payment
-            update_payments(pmt.clone());
+            update_payments(pmt);
 
             // Store this payment as a receipt to send in the future if this receiver doesnt see the payment
             store_payment(pmt);
@@ -737,7 +737,7 @@ fn handle_tx_messaging_xdai(
 /// Handles the tx response from the full node and it's various cases
 /// pulled out of validate_transaction purely for cosmetic reasons
 fn handle_tx_messaging_althea(transaction: TransactionDetails, ts: ToValidate) {
-    let pmt = ts.payment.clone();
+    let pmt = ts.payment;
 
     // txid is for eth chain and txhash is for althea chain, only one of these should be
     // Some(..). This was verified before
@@ -838,7 +838,7 @@ fn handle_tx_messaging_althea(transaction: TransactionDetails, ts: ToValidate) {
                 denom.expect("How did this happen when we already verified existence"),
             );
             // update the usage tracker with the details of this payment
-            update_payments(pmt.clone());
+            update_payments(pmt);
 
             // Store this payment as a receipt to send in the future if this receiver doesnt see the payment
             store_payment(pmt);
@@ -970,8 +970,8 @@ mod tests {
             txid: 1u8.into(),
         };
 
-        store_payment(pmt1.clone());
-        sent_hashset.insert(pmt1.clone());
+        store_payment(pmt1);
+        sent_hashset.insert(pmt1);
         assert_eq!(get_payment_txids(pmt1.to), sent_hashset);
 
         let pmt2 = PaymentTx {
@@ -980,9 +980,9 @@ mod tests {
             amount: 100u8.into(),
             txid: 2u8.into(),
         };
-        store_payment(pmt2.clone());
+        store_payment(pmt2);
 
-        sent_hashset.insert(pmt2.clone());
+        sent_hashset.insert(pmt2);
         assert_eq!(get_payment_txids(pmt2.to), sent_hashset);
 
         let pmt3 = PaymentTx {
@@ -992,7 +992,7 @@ mod tests {
             txid: 2u8.into(),
         };
 
-        store_payment(pmt3.clone());
+        store_payment(pmt3);
 
         assert_eq!(get_payment_txids(pmt3.to), sent_hashset);
     }

--- a/rita_common/src/traffic_watcher/mod.rs
+++ b/rita_common/src/traffic_watcher/mod.rs
@@ -5,9 +5,9 @@
 use crate::debt_keeper::traffic_update;
 use crate::debt_keeper::Traffic;
 use crate::tunnel_manager::Neighbor;
+use crate::usage_tracker::structs::UsageType;
 use crate::usage_tracker::update_usage_data;
 use crate::usage_tracker::UpdateUsage;
-use crate::usage_tracker::UsageType;
 use crate::RitaCommonError;
 use crate::KI;
 use althea_kernel_interface::open_tunnel::is_link_local;

--- a/rita_common/src/usage_tracker/structs.rs
+++ b/rita_common/src/usage_tracker/structs.rs
@@ -1,0 +1,163 @@
+use althea_types::{Identity, IndexedUsageHour, PaymentTx, Usage};
+use num256::Uint256;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::Hash;
+
+/// A struct for tracking each hours of payments indexed in hours since unix epoch
+/// used to send to the frontend
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PaymentHour {
+    pub index: u64,
+    pub payments: Vec<FormattedPaymentTxOld>,
+}
+
+/// Old usage tracker struct used by versions up to Beta 20 rc29 and Beta 21 rc2
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UsageTrackerStorageOld {
+    pub last_save_hour: u64,
+    // at least one of these will be left unused
+    pub client_bandwidth: VecDeque<IndexedUsageHour>,
+    pub relay_bandwidth: VecDeque<IndexedUsageHour>,
+    pub exit_bandwidth: VecDeque<IndexedUsageHour>,
+    /// A history of payments
+    pub payments: VecDeque<PaymentHour>,
+}
+
+/// Usage tracker data storage, stores information about the data usage of this
+/// Rita process
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct UsageTrackerStorage {
+    /// The last time this struct was saved to the disk
+    pub last_save_hour: u64,
+    // at least one of these will be left unused
+    /// client bandwidth usage per hour indexd by unix timestamp in hours
+    pub client_bandwidth: HashMap<u64, Usage>,
+    /// relay bandwidth usage per hour indexd by unix timestamp in hours
+    pub relay_bandwidth: HashMap<u64, Usage>,
+    /// exit bandwidth usage per hour indexd by unix timestamp in hours
+    pub exit_bandwidth: HashMap<u64, Usage>,
+    /// A history of payments
+    pub payments: HashSet<UsageTrackerPayment>,
+}
+
+impl UsageTrackerStorage {
+    pub fn get_txids(&self) -> HashSet<Uint256> {
+        let mut set = HashSet::new();
+        for p in &self.payments {
+            set.insert(p.txid);
+        }
+        set
+    }
+}
+
+/// In an effort to converge this module between the three possible bw tracking
+/// use cases this enum is used to identify which sort of usage we are tracking
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub enum UsageType {
+    Client,
+    Relay,
+    Exit,
+}
+
+/// A version of payment tx with a string txid so that the formatting is correct
+/// for display to users.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub struct FormattedPaymentTxOld {
+    pub to: Identity,
+    pub from: Identity,
+    pub amount: Uint256,
+    pub txid: String,
+}
+
+impl From<PaymentTx> for FormattedPaymentTxOld {
+    fn from(input: PaymentTx) -> Self {
+        let txid = input.txid;
+        FormattedPaymentTxOld {
+            to: input.to,
+            from: input.from,
+            amount: input.amount,
+            txid: format!("{txid:#066x}"),
+        }
+    }
+}
+
+impl From<UsageTrackerPayment> for FormattedPaymentTxOld {
+    fn from(value: UsageTrackerPayment) -> Self {
+        let txid = value.txid;
+        FormattedPaymentTxOld {
+            to: value.to,
+            from: value.from,
+            amount: value.amount,
+            txid: format!("{txid:#066x}"),
+        }
+    }
+}
+
+/// A version of payment tx with a string txid so that the formatting is correct
+/// for display to users.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct UsageTrackerPayment {
+    pub to: Identity,
+    pub from: Identity,
+    pub amount: Uint256,
+    pub txid: Uint256,
+    /// the unix timestamp in hours of when this payment occured.
+    pub index: u64,
+}
+
+impl Ord for UsageTrackerPayment {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.index.cmp(&other.index)
+    }
+}
+
+impl PartialOrd for UsageTrackerPayment {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.index.partial_cmp(&other.index)
+    }
+}
+
+impl Hash for UsageTrackerPayment {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // hash all values except the timestamp
+        self.to.hash(state);
+        self.from.hash(state);
+        self.amount.hash(state);
+        self.txid.hash(state);
+    }
+}
+
+impl UsageTrackerPayment {
+    pub fn from_payment_tx(input: PaymentTx, index: u64) -> UsageTrackerPayment {
+        UsageTrackerPayment {
+            to: input.to,
+            from: input.from,
+            amount: input.amount,
+            txid: input.txid,
+            index,
+        }
+    }
+}
+
+pub fn convert_payment_set_to_payment_hour(
+    input: HashSet<UsageTrackerPayment>,
+) -> VecDeque<PaymentHour> {
+    let mut intermediate = HashMap::new();
+    for ph in input {
+        match intermediate.get_mut(&ph.index) {
+            None => {
+                intermediate.insert(ph.index, vec![ph]);
+            }
+            Some(val) => val.push(ph),
+        }
+    }
+    let mut out = VecDeque::new();
+    for (h, phs) in intermediate {
+        out.push_back(PaymentHour {
+            index: h,
+            payments: phs.into_iter().map(|v| v.into()).collect(),
+        })
+    }
+    out
+}

--- a/rita_common/src/usage_tracker/structs.rs
+++ b/rita_common/src/usage_tracker/structs.rs
@@ -2,6 +2,25 @@ use althea_types::{Identity, IndexedUsageHour, PaymentTx, Usage};
 use num256::Uint256;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+/// This struct is used to estimate the current throughput of a given router, it is not saved out to the disk
+#[derive(Clone, Copy, Default)]
+pub struct ThroughputTracker {
+    pub client: ThroughputData,
+    pub relay: ThroughputData,
+    pub exit: ThroughputData,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct ThroughputData {
+    /// When the current data in this struct was last updated
+    pub last_sample_time: Option<Instant>,
+    /// the duration between the previous and current value of last_sample_time
+    /// used to convert the bytes used above into a rate per second
+    pub duration_of_this_sample: Duration,
+    pub bytes_used: u64,
+}
 
 /// A struct for tracking each hours of payments indexed in hours since unix epoch
 /// used to send to the frontend

--- a/rita_exit/src/traffic_watcher/mod.rs
+++ b/rita_exit/src/traffic_watcher/mod.rs
@@ -21,9 +21,9 @@ use babel_monitor::structs::Route;
 use ipnetwork::IpNetwork;
 use rita_common::debt_keeper::traffic_update;
 use rita_common::debt_keeper::Traffic;
+use rita_common::usage_tracker::structs::UsageType;
 use rita_common::usage_tracker::update_usage_data;
 use rita_common::usage_tracker::UpdateUsage;
-use rita_common::usage_tracker::UsageType;
 use std::collections::HashMap;
 use std::net::IpAddr;
 


### PR DESCRIPTION
This simple double ended iterator based design of UsageTracker has served us pretty well for a long time. We would push to the front a new usage hour and pop old ones off the back.

Sadly this format has proven to not be very robust to errors, if for any reason the usage or payments list was to become out of order invalid duplicate data would exist leading to confusing questions about which one to select.

We saw this most recently with payments where the make_payments_v2 change caused duplicate payments and incorrect income data to pollute the databases of many routers. That issue was patched with a duplicate check but in this new structure duplicates of payments in the payment list and duplicates of data usage in the data usage list are simply not possible.

By storing the usage data as a hashmap indexed by unix timestamp we will always retrieve a copy of the usage data for a given hour if we request it and only one version of any hour can exist.

Likewise for payments we've moved to a flat HashSet where the Hash value for the payment struct is the txid, this means that duplicate payments with the same txid can not co-exist in the hashset.

This new more robust format will be consumed by operator tools as well making it easier to manage usage data for many routers in the database there.