### PR TITLE
Add authentication and exit registration to exit db contract

### DIFF
--- a/solidity/contracts/AltheaDB.sol
+++ b/solidity/contracts/AltheaDB.sol
@@ -81,7 +81,7 @@ contract AltheaDB {
     }
 
     function is_exit_admin(address potential_admin) public view returns (bool) {
-        for (uint256 i = 0; i < state_UserAdmins.length; i++) {
+        for (uint256 i = 0; i < state_ExitAdmins.length; i++) {
             if (potential_admin == state_ExitAdmins[i]) {
                 return true;
             }

--- a/solidity/contracts/AltheaDB.sol
+++ b/solidity/contracts/AltheaDB.sol
@@ -1,54 +1,369 @@
 //SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.21; // Force solidity compliance
 
-contract AltheaDB {
-    constructor() {}
+/// Identity struct
+struct Identity {
+    uint128 mesh_ip;
+    uint256 wg_key;
+    address eth_addr;
+}
 
-    // Identity struct
-    struct Identity {
-        string mesh_ip;
-        string wg_key;
-        address eth_addr;
-    }
+/// Thrown when the caller is not authorized to register users
+error UnathorizedCaller();
+error DuplicateUser();
+error DuplicateAdmin();
+error IdentityNotFound();
+error AdminNotFound();
+
+contract AltheaDB {
+    /// The admin address that is allowed to update who is on the
+    /// user admin and exit admin lists. This could be an individual
+    /// account or a multisig
+    address public immutable state_admin;
+    /// A list of addresses allowed to add and remove users from the list of users
+    address[] public state_UserAdmins;
+    /// A list of addresses allowed to add and remove exits from the list of exits
+    address[] public state_ExitAdmins;
 
     // Mappings to regsitered clients
-    Identity[] private registered_users;
-    mapping(string => Identity) private wg_key_to_reg_users_map;
-    mapping(string => Identity) private mesh_ip_to_reg_users_map;
-    mapping(address => Identity) private eth_addr_to_reg_users_map;
+    Identity[] public state_registeredUsers;
+    // Mappings to regsitered exits
+    Identity[] public state_registeredExits;
+
+    event UserRegisteredEvent(Identity indexed _user);
+    event UserRemovedEvent(Identity indexed _user);
+    event ExitRegisteredEvent(Identity indexed _user);
+    event ExitRemovedEvent(Identity indexed _user);
+    event UserAdminAddedEvent(address indexed _admin);
+    event UserAdminRemovedEvent(address indexed _admin);
+    event ExitAdminAddedEvent(address indexed _admin);
+    event ExitAdminRemovedEvent(address indexed _admin);
+
+    constructor(address _admin) {
+        state_admin = _admin;
+    }
+
+    // start utility function 
+
+    function get_null_identity() public pure returns (Identity memory) {
+        return Identity({mesh_ip: 0, wg_key: 0, eth_addr: address(0)});
+    }
+
+    function is_null_identity(
+        Identity calldata input
+    ) public pure returns (bool) {
+        return identities_are_equal(input, get_null_identity());
+    }
+
+    function identities_are_equal(
+        Identity memory a,
+        Identity memory b
+    ) public pure returns (bool) {
+        if (a.mesh_ip != b.mesh_ip) {
+            return false;
+        }
+        if (a.wg_key != b.wg_key) {
+            return false;
+        }
+        if (a.eth_addr != b.eth_addr) {
+            return false;
+        }
+        return true;
+    }
+
+    function is_user_admin(address potential_admin) public view returns (bool) {
+        for (uint256 i = 0; i < state_UserAdmins.length; i++) {
+            if (potential_admin == state_UserAdmins[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function is_exit_admin(address potential_admin) public view returns (bool) {
+        for (uint256 i = 0; i < state_UserAdmins.length; i++) {
+            if (potential_admin == state_ExitAdmins[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Deletes an entry of the provided array
+    function delete_array_entry(uint index, Identity[] storage array) private {
+        require(index < array.length);
+        // copy the last element into the index that we want to delete
+        // in the case that we want to delete the last element, just skip this
+        if (index != array.length -1) {
+            array[index] = array[array.length - 1];
+        }
+        // drop the new duplicated end element effectively deleting the originally
+        // specified index
+        array.pop();
+    }
+
+    /// Deletes an entry of the provided array
+    function delete_array_entry(uint index, address[] storage array) private {
+        require(index < array.length);
+        // copy the last element into the index that we want to delete
+        // in the case that we want to delete the last element, just skip this
+        if (index != array.length -1) {
+            array[index] = array[array.length - 1];
+        }
+        // drop the new duplicated end element effectively deleting the originally
+        // specified index
+        array.pop();
+    }
+
+    function get_index_of_id(Identity memory id, Identity[] memory array) private pure returns (uint256) {
+        for (uint256 i = 0; i < array.length; i++) {
+            if (identities_are_equal(array[i], id)) {
+                return i;
+            }
+        }
+        revert IdentityNotFound();
+    }
+
+    function get_index_of_admin(address admin, address[] memory array) private pure returns (uint256) {
+        for (uint256 i = 0; i < array.length; i++) {
+            if (admin == array[i]) {
+                return i;
+            }
+        }
+        revert AdminNotFound();
+    }
+
+    /// Checks both the exit and the client lists for any entry with any
+    /// sort of duplicate ID component
+    function check_for_any_duplicates(
+        Identity calldata entry
+    ) public view returns (bool) {
+        if (
+            !identities_are_equal(
+                get_registered_exit_with_eth_addr(entry.eth_addr),
+                get_null_identity()
+            )
+        ) {
+            return true;
+        }
+        if (
+            !identities_are_equal(
+                get_registered_exit_with_mesh_ip(entry.mesh_ip),
+                get_null_identity()
+            )
+        ) {
+            return true;
+        }
+        if (
+            !identities_are_equal(
+                get_registered_exit_with_wg_key(entry.wg_key),
+                get_null_identity()
+            )
+        ) {
+            return true;
+        }
+
+        if (
+            !identities_are_equal(
+                get_registered_client_with_eth_addr(entry.eth_addr),
+                get_null_identity()
+            )
+        ) {
+            return true;
+        }
+        if (
+            !identities_are_equal(
+                get_registered_client_with_mesh_ip(entry.mesh_ip),
+                get_null_identity()
+            )
+        ) {
+            return true;
+        }
+        if (
+            !identities_are_equal(
+                get_registered_client_with_wg_key(entry.wg_key),
+                get_null_identity()
+            )
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    // start user and exit management functions
 
     // Add a new registered user
-    function add_registered_user(Identity memory entry) public {
-        registered_users.push(entry);
-        wg_key_to_reg_users_map[entry.wg_key] = entry;
-        mesh_ip_to_reg_users_map[entry.mesh_ip] = entry;
-        eth_addr_to_reg_users_map[entry.eth_addr] = entry;
+    function add_registered_user(Identity calldata entry) public {
+        if (is_user_admin(msg.sender)) {
+            // if any client or exit currently registered has overlapping data, do not allow the
+            // registration to continue
+            if (check_for_any_duplicates(entry)) {
+                revert DuplicateUser();
+            }
+
+            state_registeredUsers.push(entry);
+            emit UserRegisteredEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
     }
 
-    // Get all registered users
-    function get_all_registered_users()
-        public
-        view
-        returns (Identity[] memory)
-    {
-        return registered_users;
+    // Remove a new registered user
+    function remove_registered_user(Identity calldata entry) public {
+        if (is_user_admin(msg.sender)) {
+            uint256 index = get_index_of_id(entry, state_registeredUsers);
+            delete_array_entry(index, state_registeredUsers);
+            emit UserRemovedEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
     }
+
+    // Add a new registered exit
+    function add_registered_exit(Identity calldata entry) public {
+        if (is_exit_admin(msg.sender)) {
+            // if any client or exit currently registered has overlapping data, do not allow the
+            // registration to continue
+            if (check_for_any_duplicates(entry)) {
+                revert DuplicateUser();
+            }
+
+            state_registeredExits.push(entry);
+            emit ExitRegisteredEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
+    }
+
+    // Remove a new registered exit
+    function remove_registered_exit(Identity calldata entry) public {
+        if (is_exit_admin(msg.sender)) {
+            uint256 index = get_index_of_id(entry, state_registeredExits);
+            delete_array_entry(index, state_registeredExits);
+            emit ExitRemovedEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
+    }
+
+    // start user query functions
+
 
     function get_registered_client_with_wg_key(
-        string memory wg_key
+        uint256 wg_key
     ) public view returns (Identity memory) {
-        return wg_key_to_reg_users_map[wg_key];
+        for (uint256 i = 0; i < state_registeredUsers.length; i++) {
+            if (state_registeredUsers[i].wg_key == wg_key) {
+                return state_registeredUsers[i];
+            }
+        }
+        return get_null_identity();
     }
 
     function get_registered_client_with_mesh_ip(
-        string memory mesh_ip
+        uint128 mesh_ip
     ) public view returns (Identity memory) {
-        return mesh_ip_to_reg_users_map[mesh_ip];
+        for (uint256 i = 0; i < state_registeredUsers.length; i++) {
+            if (state_registeredUsers[i].mesh_ip == mesh_ip) {
+                return state_registeredUsers[i];
+            }
+        }
+        return get_null_identity();
     }
 
     function get_registered_client_with_eth_addr(
         address eth_addr
     ) public view returns (Identity memory) {
-        return eth_addr_to_reg_users_map[eth_addr];
+        for (uint256 i = 0; i < state_registeredUsers.length; i++) {
+            if (state_registeredUsers[i].eth_addr == eth_addr) {
+                return state_registeredUsers[i];
+            }
+        }
+        return get_null_identity();
+    }
+
+    function get_registered_exit_with_wg_key(
+        uint256 wg_key
+    ) public view returns (Identity memory) {
+        for (uint256 i = 0; i < state_registeredExits.length; i++) {
+            if (state_registeredExits[i].wg_key == wg_key) {
+                return state_registeredExits[i];
+            }
+        }
+        return get_null_identity();
+    }
+
+    function get_registered_exit_with_mesh_ip(
+        uint128 mesh_ip
+    ) public view returns (Identity memory) {
+        for (uint256 i = 0; i < state_registeredExits.length; i++) {
+            if (state_registeredExits[i].mesh_ip == mesh_ip) {
+                return state_registeredExits[i];
+            }
+        }
+        return get_null_identity();
+    }
+
+    function get_registered_exit_with_eth_addr(
+        address eth_addr
+    ) public view returns (Identity memory) {
+        for (uint256 i = 0; i < state_registeredExits.length; i++) {
+            if (state_registeredExits[i].eth_addr == eth_addr) {
+                return state_registeredExits[i];
+            }
+        }
+        return get_null_identity();
+    }
+
+    // start admin management functions
+
+    // Add a new user admin
+    function add_user_admin(address entry) public {
+        if (state_admin == msg.sender) {
+            if (is_user_admin(entry)) {
+                revert DuplicateAdmin();
+            }
+
+            state_UserAdmins.push(entry);
+            emit UserAdminAddedEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
+    }
+
+    // Remove a user admin
+    function remove_user_admin(address entry) public {
+        if (state_admin == msg.sender) {
+            uint256 index = get_index_of_admin(entry, state_UserAdmins);
+            delete_array_entry(index, state_UserAdmins);
+            emit UserAdminAddedEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
+    }
+
+    // Add a new exit admin
+    function add_exit_admin(address entry) public {
+        if (state_admin == msg.sender) {
+            if (is_exit_admin(entry)) {
+                revert DuplicateAdmin();
+            }
+
+            state_ExitAdmins.push(entry);
+            emit ExitAdminAddedEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
+    }
+
+    // Remove a exit admin
+    function remove_exit_admin(address entry) public {
+        if (state_admin == msg.sender) {
+            uint256 index = get_index_of_admin(entry, state_ExitAdmins);
+            delete_array_entry(index, state_ExitAdmins);
+            emit UserAdminAddedEvent(entry);
+        } else {
+            revert UnathorizedCaller();
+        }
     }
 }

--- a/solidity/contracts/AltheaDB.sol
+++ b/solidity/contracts/AltheaDB.sol
@@ -11,11 +11,14 @@ struct Identity {
 /// Identity struct for an exit, including a list of allowed region codes
 /// This is to protect a user from connecting to an exit that does not allow
 /// their region despite providing the best connection metrics otherwise
+/// The payment types specification prevents clients from moving to exits
+/// that do not accept their tokens as payment
 struct ExitIdentity {
     uint128 mesh_ip;
     uint256 wg_key;
     address eth_addr;
     uint256[] allowed_regions;
+    uint256[] payment_types;
 }
 
 /// Thrown when the caller is not authorized to register users
@@ -69,7 +72,7 @@ contract AltheaDB {
 
     function get_null_exit_identity() public pure returns (ExitIdentity memory) {
         uint256[] memory empty_array;
-        return ExitIdentity({mesh_ip: 0, wg_key: 0, eth_addr: address(0), allowed_regions: empty_array});
+        return ExitIdentity({mesh_ip: 0, wg_key: 0, eth_addr: address(0), allowed_regions: empty_array, payment_types: empty_array});
     }
 
     function is_null_identity(

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "rita-contracts",
       "version": "1.0.0",
-      "license": "None",
+      "license": "Apache-2.0",
       "dependencies": {
         "pkg": "^4.4.9"
       },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -7,11 +7,10 @@
     "evm": "npx hardhat node",
     "test": "npx hardhat test",
     "typechain": "npx hardhat typechain",
-    "compile-deployer": "npx tsc -p . ; pkg dist/contract-deployer.js --targets node10-linux-x64",
-    "evm_fork": "npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_ID} --fork-block-number 12782071"
+    "compile-deployer": "npx tsc -p . ; pkg dist/contract-deployer.js --targets node10-linux-x64"
   },
-  "author": "Jehan Tremback, Christian Borst",
-  "license": "None",
+  "author": "Justin Kilpatrick, Pranay Telegu, Christian Borst",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^9.1.2",

--- a/solidity/test-utils/index.ts
+++ b/solidity/test-utils/index.ts
@@ -17,7 +17,7 @@ export async function deployContracts(signer?: Signer | undefined) {
   const testERC20C = (await TestERC20C.deploy()) as TestERC20C;
 
   const AltheaDB = await ethers.getContractFactory("AltheaDB", signer);
-  const althea_db = (await AltheaDB.deploy()) as AltheaDB;
+  const althea_db = (await AltheaDB.deploy(signer?.getAddress())) as AltheaDB;
 
   return { testERC20A, testERC20B, testERC20C, althea_db };
 }

--- a/solidity/test/altheaDBTests.ts
+++ b/solidity/test/altheaDBTests.ts
@@ -3,27 +3,172 @@ import { ethers } from "hardhat";
 import { solidity } from "ethereum-waffle";
 
 import { deployContracts } from "../test-utils";
+import { assert } from "console";
 
 chai.use(solidity);
 const { expect } = chai;
 
-async function runTest(opts: {}) {
-  const signers = await ethers.getSigners();
-  const sender = signers[0];
-  const exit_admin = signers[1];
-  const user_admin = signers[2];
-
-  // Deploy several ERC20 tokens
-  const { althea_db } = await deployContracts(sender)
-
-
-
-
-
+function expectId(a: any, b: any) {
+  expect(a.mesh_ip).to.equal(b.mesh_ip)
+  expect(a.eth_addr).to.equal(b.eth_addr)
+  expect(a.wg_key).to.equal(b.wg_key)
 }
 
-describe("ERC20Transfer tests", function () {
-  it("emits Transfer events correctly", async function () {
-    await runTest({})
+async function addUser(opts: {
+  with_admin: boolean,
+  try_duplicate: boolean,
+  try_partial_dup: boolean,
+}) {
+  const signers = await ethers.getSigners();
+  const sender = signers[0];
+  let user1 = {
+    mesh_ip: "0xfd001337",
+    wg_key: "0xAFEDB",
+    eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
+  };
+  let user2 = {
+    mesh_ip: "0xfd001329",
+    wg_key: "0xAFEDD",
+    eth_addr: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+  };
+  let partialDup = {
+    mesh_ip: "0xfd001338",
+    wg_key: "0xAFEDB",
+    eth_addr: "0x154CB202089D58efB56a2B11ce812Ae3882fE1f3",
+  };
+  let nullUser = {
+    mesh_ip: "0x0",
+    wg_key: "0x0",
+    eth_addr: "0x0000000000000000000000000000000000000000",
+  };
+  const { althea_db } = await deployContracts(sender);
+  if (opts.with_admin) {
+    await althea_db.add_user_admin(await sender?.getAddress());
+  }
+  await althea_db.add_registered_user(user1)
+  expectId(await althea_db.get_registered_client_with_eth_addr(user1.eth_addr), user1)
+  expectId(await althea_db.get_registered_client_with_wg_key(user1.wg_key), user1)
+  expectId(await althea_db.get_registered_client_with_mesh_ip(user1.mesh_ip), user1)
+  await althea_db.add_registered_user(user2)
+  expectId(await althea_db.get_registered_client_with_eth_addr(user2.eth_addr), user2)
+  expectId(await althea_db.get_registered_client_with_wg_key(user2.wg_key), user2)
+  expectId(await althea_db.get_registered_client_with_mesh_ip(user2.mesh_ip), user2)
+
+  if (opts.try_duplicate) {
+    await althea_db.add_registered_user(user1)
+  }
+  if (opts.try_partial_dup) {
+    await althea_db.add_registered_user(partialDup)
+  }
+
+  await althea_db.remove_registered_user(user1)
+  expectId(await althea_db.get_registered_client_with_eth_addr(user1.eth_addr), nullUser)
+  expectId(await althea_db.get_registered_client_with_wg_key(user1.wg_key), nullUser)
+  expectId(await althea_db.get_registered_client_with_mesh_ip(user1.mesh_ip), nullUser)
+  expectId(await althea_db.get_registered_client_with_eth_addr(user2.eth_addr), user2)
+  expectId(await althea_db.get_registered_client_with_wg_key(user2.wg_key), user2)
+  expectId(await althea_db.get_registered_client_with_mesh_ip(user2.mesh_ip), user2)
+}
+
+async function addExit(opts: {
+  with_admin: boolean,
+  try_duplicate: boolean,
+  try_partial_dup: boolean,
+}) {
+  const signers = await ethers.getSigners();
+  const sender = signers[0];
+  let user1 = {
+    mesh_ip: "0xfd001337",
+    wg_key: "0xAFEDB",
+    eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
+  };
+  let user2 = {
+    mesh_ip: "0xfd001329",
+    wg_key: "0xAFEDD",
+    eth_addr: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+  };
+  let partialDup = {
+    mesh_ip: "0xfd001338",
+    wg_key: "0xAFEDB",
+    eth_addr: "0x154CB202089D58efB56a2B11ce812Ae3882fE1f3",
+  };
+  let nullUser = {
+    mesh_ip: "0x0",
+    wg_key: "0x0",
+    eth_addr: "0x0000000000000000000000000000000000000000",
+  };
+  const { althea_db } = await deployContracts(sender);
+  if (opts.with_admin) {
+    await althea_db.add_exit_admin(await sender?.getAddress());
+  }
+  await althea_db.add_registered_exit(user1)
+  expectId(await althea_db.get_registered_exit_with_eth_addr(user1.eth_addr), user1)
+  expectId(await althea_db.get_registered_exit_with_wg_key(user1.wg_key), user1)
+  expectId(await althea_db.get_registered_exit_with_mesh_ip(user1.mesh_ip), user1)
+  await althea_db.add_registered_exit(user2)
+  expectId(await althea_db.get_registered_exit_with_eth_addr(user2.eth_addr), user2)
+  expectId(await althea_db.get_registered_exit_with_wg_key(user2.wg_key), user2)
+  expectId(await althea_db.get_registered_exit_with_mesh_ip(user2.mesh_ip), user2)
+
+  if (opts.try_duplicate) {
+    await althea_db.add_registered_exit(user1)
+  }
+  if (opts.try_partial_dup) {
+    await althea_db.add_registered_exit(partialDup)
+  }
+
+  await althea_db.remove_registered_exit(user1)
+  expectId(await althea_db.get_registered_exit_with_eth_addr(user1.eth_addr), nullUser)
+  expectId(await althea_db.get_registered_exit_with_wg_key(user1.wg_key), nullUser)
+  expectId(await althea_db.get_registered_exit_with_mesh_ip(user1.mesh_ip), nullUser)
+  expectId(await althea_db.get_registered_exit_with_eth_addr(user2.eth_addr), user2)
+  expectId(await althea_db.get_registered_exit_with_wg_key(user2.wg_key), user2)
+  expectId(await althea_db.get_registered_exit_with_mesh_ip(user2.mesh_ip), user2)
+}
+
+
+
+describe("Althea exit DB tests", function () {
+  it("throws on unauthorized caller", async function () {
+    await expect(addUser({ with_admin: false, try_duplicate: false, try_partial_dup: false })
+    ).to.be.revertedWith(
+      "UnathorizedCaller()"
+    );
+  });
+  it("User registration happy path", async function () {
+    addUser({ with_admin: true, try_duplicate: false, try_partial_dup: false })
+  });
+  it("throws on User duplicate", async function () {
+    await expect(addUser({ with_admin: true, try_duplicate: true, try_partial_dup: false })
+    ).to.be.revertedWith(
+      "DuplicateUser()"
+    );
+  });
+  it("throws on User partial duplicate", async function () {
+    await expect(addUser({ with_admin: true, try_duplicate: true, try_partial_dup: true })
+    ).to.be.revertedWith(
+      "DuplicateUser()"
+    );
+  });
+  it("throws on unauthorized caller", async function () {
+    await expect(addExit({ with_admin: false, try_duplicate: false, try_partial_dup: false })
+    ).to.be.revertedWith(
+      "UnathorizedCaller()"
+    );
+  });
+  it("Exit registration happy path", async function () {
+    addExit({ with_admin: true, try_duplicate: false, try_partial_dup: false })
+  });
+  it("throws on Exit duplicate", async function () {
+    await expect(addExit({ with_admin: true, try_duplicate: true, try_partial_dup: false })
+    ).to.be.revertedWith(
+      "DuplicateUser()"
+    );
+  });
+  it("throws on Exit partial duplicate", async function () {
+    await expect(addExit({ with_admin: true, try_duplicate: true, try_partial_dup: true })
+    ).to.be.revertedWith(
+      "DuplicateUser()"
+    );
   });
 });

--- a/solidity/test/altheaDBTests.ts
+++ b/solidity/test/altheaDBTests.ts
@@ -1,0 +1,29 @@
+import chai from "chai";
+import { ethers } from "hardhat";
+import { solidity } from "ethereum-waffle";
+
+import { deployContracts } from "../test-utils";
+
+chai.use(solidity);
+const { expect } = chai;
+
+async function runTest(opts: {}) {
+  const signers = await ethers.getSigners();
+  const sender = signers[0];
+  const exit_admin = signers[1];
+  const user_admin = signers[2];
+
+  // Deploy several ERC20 tokens
+  const { althea_db } = await deployContracts(sender)
+
+
+
+
+
+}
+
+describe("ERC20Transfer tests", function () {
+  it("emits Transfer events correctly", async function () {
+    await runTest({})
+  });
+});

--- a/solidity/test/altheaDBTests.ts
+++ b/solidity/test/altheaDBTests.ts
@@ -81,21 +81,31 @@ async function addExit(opts: {
     mesh_ip: "0xfd001337",
     wg_key: "0xAFEDB",
     eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
+    allowed_regions: [1, 3]
+  };
+  let user1ButDifferentRegions = {
+    mesh_ip: "0xfd001337",
+    wg_key: "0xAFEDB",
+    eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
+    allowed_regions: [16, 25]
   };
   let user2 = {
     mesh_ip: "0xfd001329",
     wg_key: "0xAFEDD",
     eth_addr: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+    allowed_regions: []
   };
   let partialDup = {
     mesh_ip: "0xfd001338",
     wg_key: "0xAFEDB",
     eth_addr: "0x154CB202089D58efB56a2B11ce812Ae3882fE1f3",
+    allowed_regions: []
   };
   let nullUser = {
     mesh_ip: "0x0",
     wg_key: "0x0",
     eth_addr: "0x0000000000000000000000000000000000000000",
+    allowed_regions: []
   };
   const { althea_db } = await deployContracts(sender);
   if (opts.with_admin) {
@@ -117,7 +127,7 @@ async function addExit(opts: {
     await althea_db.add_registered_exit(partialDup)
   }
 
-  await althea_db.remove_registered_exit(user1)
+  await althea_db.remove_registered_exit(user1ButDifferentRegions)
   expectId(await althea_db.get_registered_exit_with_eth_addr(user1.eth_addr), nullUser)
   expectId(await althea_db.get_registered_exit_with_wg_key(user1.wg_key), nullUser)
   expectId(await althea_db.get_registered_exit_with_mesh_ip(user1.mesh_ip), nullUser)

--- a/solidity/test/altheaDBTests.ts
+++ b/solidity/test/altheaDBTests.ts
@@ -43,7 +43,8 @@ async function addUser(opts: {
     mesh_ip: "0xfd001338",
     wg_key: "0xAFEDB",
     eth_addr: "0x154CB202089D58efB56a2B11ce812Ae3882fE1f3",
-    allowed_regions: []
+    allowed_regions: [],
+    payment_types: []
   };
   let nullUser = {
     mesh_ip: "0x0",
@@ -112,25 +113,29 @@ async function addExit(opts: {
     mesh_ip: "0xfd001337",
     wg_key: "0xAFEDB",
     eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
-    allowed_regions: [1, 3]
+    allowed_regions: [1, 3],
+    payment_types: [5, 6],
   };
   let user1ButDifferentRegions = {
     mesh_ip: "0xfd001337",
     wg_key: "0xAFEDB",
     eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
-    allowed_regions: [16, 25]
+    allowed_regions: [16, 25],
+    payment_types: [8, 9],
   };
   let user2 = {
     mesh_ip: "0xfd001329",
     wg_key: "0xAFEDD",
     eth_addr: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
-    allowed_regions: []
+    allowed_regions: [],
+    payment_types: []
   };
   let partialDup = {
     mesh_ip: "0xfd001338",
     wg_key: "0xAFEDB",
     eth_addr: "0x154CB202089D58efB56a2B11ce812Ae3882fE1f3",
-    allowed_regions: []
+    allowed_regions: [],
+    payment_types: []
   };
   let crossDup = {
     mesh_ip: "0xfd001338",
@@ -141,7 +146,8 @@ async function addExit(opts: {
     mesh_ip: "0x0",
     wg_key: "0x0",
     eth_addr: "0x0000000000000000000000000000000000000000",
-    allowed_regions: []
+    allowed_regions: [],
+    payment_types: []
   };
   const { althea_db } = await deployContracts(sender);
   if (opts.with_admin) {

--- a/solidity/test/erc20Transfer.ts
+++ b/solidity/test/erc20Transfer.ts
@@ -42,20 +42,6 @@ async function runTest(opts: {}) {
   ).to
     .emit(testERC20A, 'Transfer')
     .withArgs(sender.address, receiver.address, amount);
-
-  althea_db.add_registered_user({
-    mesh_ip: "fd00::1337",
-    wg_key: "asfsdf",
-    eth_addr: "0x054CA202089D58efB56a2B11ce812Ae3882fE1f3",
-  })
-
-  althea_db.add_registered_user({
-    mesh_ip: "fd00::1447",
-    wg_key: "lkjalsdjfl",
-    eth_addr: "0x76a884Fb9cCbA3C97b04Fc50c01c6E7b0ec54e30",
-  })
-
-  console.log(await althea_db.get_all_registered_users())
 }
 
 describe("ERC20Transfer tests", function () {


### PR DESCRIPTION
This patch overhauls the exit db contract in a number of ways to prepare it for a production deployment.

1) The identity struct now stores mesh ip's as a uint128 and wireguard
   keys as a uint256 these are both superior storage methods to strings
   becuase valid ipv6 addresses and wireguard addresses are exactly
   these sizes. It's not otherwise possible to perform sufficient
   vlaidation of incoming data to ensure that any given string is a
   valid wireguard key or ipv6 address

2) Functions for adding and removing admins and permissions for user
   management in general. This is a required feature for a production
   implementation of this contract. Currently the 'super admin' capable
   of adding and removing individual admins is intended to be a Genosis
   Safe but could in theory simply be a secure single address

3) The capability to remove users has been added

4) The exit registry has been added as a parallel but otherwise
   identical data store to the user data store.

Currently this contract does not have any valid unit tests (also a requirement for production) and needs to be hooked into the router software.