### PR TITLE
Fix update_dns_conf to avoid adding nameservers 

### DIFF
--- a/rita_client/src/rita_loop/mod.rs
+++ b/rita_client/src/rita_loop/mod.rs
@@ -334,17 +334,22 @@ pub fn update_dns_conf() {
     match File::open(resolv_path) {
         Ok(file) => {
             let reader = BufReader::new(file);
+            let mut found = false;
             for line in reader.lines() {
                 let s = line.unwrap_or("".to_string());
                 if s.trim() == "nameserver 172.168.0.254" {
                     info!("Found nameserver 172.168.0.254, no update to resolv.conf");
+                    found = true;
                 }
             }
-            // if we get here we haven't found the nameserver and need to add it
-            match fs::write(resolv_path, updated_config) {
-                Ok(_) => info!("Updating resolv.conf"),
-                Err(e) => error!("Could not update resolv.conf with {:?}", e),
-            };
+
+            if !found {
+                // if we get here we haven't found the nameserver and need to add it
+                match fs::write(resolv_path, updated_config) {
+                    Ok(_) => info!("Updating resolv.conf"),
+                    Err(e) => error!("Could not update resolv.conf with {:?}", e),
+                };
+            }
         }
         Err(_e) => {
             match fs::write(resolv_path, updated_config) {


### PR DESCRIPTION
In update_dns_conf there is a check to see if the local exit nameserver is present in /etc/resolv.conf, and if it isn't, then rita adds a list of default nameservers.  The bug is that it adds the list of nameservers regardless of whether it finds the local one already there. 

Here's the log output of the bug
```
[2023-10-05T14:44:27Z INFO  rita_client::rita_loop] Found nameserver 172.168.0.254, no update to resolv.conf
[2023-10-05T14:44:27Z INFO  rita_client::rita_loop] Updating resolv.conf
```
