### PR TITLE
Reduce the maximum block iteration size for withdraw checks

### DIFF
--- a/rita_common/src/token_bridge/mod.rs
+++ b/rita_common/src/token_bridge/mod.rs
@@ -45,7 +45,7 @@ pub const ETH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(600);
 
 const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000_u128;
 const SIGNATURES_TIMEOUT: Duration = ETH_TRANSFER_TIMEOUT;
-const BLOCKS: u64 = 40_032;
+const BLOCKS: u64 = 720;
 
 pub fn eth_to_wei(eth: u64) -> Uint256 {
     let wei = eth as u128 * WEI_PER_ETH;

--- a/rita_common/src/token_bridge/xdai_bridge.rs
+++ b/rita_common/src/token_bridge/xdai_bridge.rs
@@ -183,7 +183,7 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
 }
 
 /// This function is called inside the bridge loop. It retrieves the 'n' most recent blocks
-/// (where 'n' is the const 'BLOCKS' that is currently set to 40,032, which represents 1 week of blocks on xdai chain) that
+/// (where 'n' is the const 'BLOCKS' that is currently set to 720, which represents 1 hour of blocks on xdai chain) that
 /// have withdraw events related to our address. It then simulates these events and submits
 /// the signatures needed to unlock the funds.
 pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(), TokenBridgeError> {
@@ -191,7 +191,7 @@ pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(),
     let mut h = HashSet::new();
     h.insert(bridge.own_address);
 
-    let events = check_withdrawals(BLOCKS, bridge.xdai_bridge_on_xdai, client, h).await?;
+    let events = check_withdrawals(BLOCKS, bridge.xdai_bridge_on_xdai, client, h, None).await?;
 
     for event in events.iter() {
         let txid = event.txid;


### PR DESCRIPTION
In order to reduce load on the xdai nodes we recently set more restrictive limits on queries. Apparently the 10k block limit here exceeds that.