### PR TITLE
Fix: repeated payment bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -55,9 +55,9 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.3",
- "base64 0.21.4",
- "bitflags 2.4.0",
+ "ahash 0.8.4",
+ "base64 0.21.5",
+ "bitflags 2.4.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio",
  "tracing",
 ]
@@ -192,7 +192,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.8.3",
+ "ahash 0.8.4",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -211,20 +211,20 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "time",
  "url",
 ]
 
 [[package]]
 name = "actix-web-httpauth"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dda62cf04bc3a9ad2ea8f314f721951cfdb4cdacec4e984d20e77c7bb170991"
+checksum = "1d613edf08a42ccc6864c941d30fe14e1b676a77d16f1dbadc1174d065a0a775"
 dependencies = [
  "actix-utils",
  "actix-web",
- "base64 0.13.1",
+ "base64 0.21.5",
  "futures-core",
  "futures-util",
  "log",
@@ -239,7 +239,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -270,21 +270,22 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "72832d73be48bac96a5d7944568f305d829ed55b0ce3b483647089dfaf6cf704"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -379,6 +380,7 @@ name = "antenna_forwarding_protocol"
 version = "0.1.0"
 dependencies = [
  "althea_types",
+ "clarity",
  "lazy_static",
  "log",
  "rand",
@@ -422,18 +424,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -444,7 +446,9 @@ dependencies = [
  "clarity",
  "futures 0.3.28",
  "log",
+ "num",
  "num256",
+ "rand",
  "serde",
  "serde_derive",
  "web30",
@@ -468,7 +472,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes",
  "cfg-if",
  "cookie",
@@ -579,9 +583,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bech32"
@@ -606,9 +610,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -696,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -707,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "da74e2b81409b1b743f8f0c62cc6254afefb8b8e50bbfe3735550f7aeefa3448"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -717,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"
@@ -745,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -788,13 +792,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clarity"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a212766da516c900407d799b70635c79d6c1ca95f85a545f1edad10e197542"
+checksum = "273c656822c0367587c0fc6ae5a0bf6e19a10d700cd49168a084975b7f84dcfe"
 dependencies = [
  "num-traits",
  "num256",
- "secp256k1",
+ "secp256k1 0.28.0",
  "serde",
  "serde_derive",
  "sha3",
@@ -883,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
 dependencies = [
  "libc",
 ]
@@ -945,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dd3eeda5582365b7f15ba9d3fa196efde6d344ac9d63eb3dd1c03e169acb17"
 dependencies = [
  "althea_proto",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bech32",
  "bytes",
  "clarity",
@@ -960,7 +964,7 @@ dependencies = [
  "rand",
  "ripemd",
  "rust_decimal",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -973,9 +977,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_more"
@@ -1074,7 +1081,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfb21b9878cf7a348dcb8559109aabc0ec40d69924bd706fa5149846c4fef75"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "memchr",
 ]
 
@@ -1114,23 +1121,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1144,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fixedbitset"
@@ -1156,9 +1152,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1262,7 +1258,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1405,20 +1401,26 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex-literal"
@@ -1503,7 +1505,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1573,12 +1575,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -1639,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "ipnetwork"
@@ -1661,15 +1663,6 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1709,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -1752,7 +1745,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bd09637ae3ec7bd605b8e135e757980b3968430ff2b1a4a94fb7769e50166d"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "email-encoding",
  "email_address",
  "fastrand 1.9.0",
@@ -1766,16 +1759,16 @@ dependencies = [
  "once_cell",
  "quoted_printable",
  "serde",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libsodium-sys"
@@ -1797,19 +1790,18 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "local-channel"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+checksum = "e0a493488de5f18c8ffcba89eebb8532ffc562dc400490eb65b84893fae0b178"
 dependencies = [
  "futures-core",
  "futures-sink",
- "futures-util",
  "local-waker",
 ]
 
@@ -1821,9 +1813,9 @@ checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1862,24 +1854,25 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchit"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
+ "cfg-if",
  "digest",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -1943,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
@@ -2003,7 +1996,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -2019,10 +2012,77 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.16"
+name = "num"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -2075,7 +2135,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c75a0ec2d1b302412fb503224289325fcc0e44600176864804c7211b055cfd58"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "byteorder",
  "md-5",
  "sha2",
@@ -2088,7 +2148,7 @@ version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2105,7 +2165,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2116,9 +2176,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.3+3.1.2"
+version = "300.1.5+3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
+checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
 dependencies = [
  "cc",
 ]
@@ -2159,13 +2219,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -2194,9 +2254,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2205,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2215,22 +2275,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
 dependencies = [
  "once_cell",
  "pest",
@@ -2244,19 +2304,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
 ]
 
 [[package]]
 name = "phonenumber"
-version = "0.3.2+8.13.9"
+version = "0.3.3+8.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34749f64ea9d76f10cdc8a859588b57775f59177c7dd91f744d620bd62982d6f"
+checksum = "635f3e6288e4f01c049d89332a031bd74f25d64b6fb94703ca966e819488cd06"
 dependencies = [
  "bincode",
  "either",
  "fnv",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "nom",
  "quick-xml",
@@ -2264,6 +2324,7 @@ dependencies = [
  "regex-cache",
  "serde",
  "serde_derive",
+ "strum",
  "thiserror",
 ]
 
@@ -2284,7 +2345,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2304,6 +2365,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2331,18 +2398,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8473a65b88506c106c28ae905ca4a2b83a2993640467a41bb3080627ddfd2c"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2350,22 +2417,22 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56075c27b20ae524d00f247b8a4dc333e5784f889fe63099f8e626bc8d73486c"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cebe0a918c97f86c217b0f76fd754e966f8b9f41595095cf7d74cb4e59d730f6"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
  "prost",
 ]
@@ -2471,26 +2538,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.5"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2513,26 +2589,26 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2553,6 +2629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -2631,6 +2708,7 @@ version = "0.21.2"
 dependencies = [
  "actix",
  "actix-web",
+ "actix-web-httpauth",
  "althea_kernel_interface",
  "althea_types",
  "antenna_forwarding_client",
@@ -2638,6 +2716,7 @@ dependencies = [
  "awc",
  "babel_monitor",
  "clarity",
+ "clu",
  "compressed_log",
  "futures 0.3.28",
  "hex-literal",
@@ -2844,11 +2923,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2885,14 +2964,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -2965,7 +3044,16 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
+dependencies = [
+ "secp256k1-sys 0.9.0",
 ]
 
 [[package]]
@@ -2973,6 +3061,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
 dependencies = [
  "cc",
 ]
@@ -3002,15 +3099,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
@@ -3027,20 +3124,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -3081,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3092,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3143,15 +3240,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -3159,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -3192,6 +3289,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.33"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3224,6 +3343,27 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "tap"
@@ -3238,17 +3378,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
- "redox_syscall",
+ "fastrand 2.0.1",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -3276,32 +3416,33 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -3309,15 +3450,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -3339,9 +3480,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3351,7 +3492,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
@@ -3374,7 +3515,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3422,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3445,14 +3586,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5469afaf78a11265c343a88969045c1568aa8ecc6c787dbf756e92e70f199861"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes",
  "flate2",
  "h2",
@@ -3463,6 +3604,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
@@ -3508,11 +3650,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3521,20 +3662,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -3547,9 +3688,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
@@ -3597,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
 ]
@@ -3662,7 +3803,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -3696,7 +3837,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3719,9 +3860,9 @@ dependencies = [
 
 [[package]]
 name = "web30"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e80f49f34c38a88dc1a04b7f77710d52d8afed7631656e4f1110c3f1fbc618"
+checksum = "3419dff65e026307b5df735b38df61d590a0d57e8040e545d1d1f433cbd0b621"
 dependencies = [
  "awc",
  "clarity",
@@ -3760,9 +3901,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -3859,6 +4000,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "zstd"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,11 +4040,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "rita_bin"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "rita_client"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "actix",
  "actix-web",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "rita_common"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "actix",
  "actix-service",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "rita_exit"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "actix",
  "actix-web",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "rita_extender"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "actix",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,7 @@ inherits = "dev"
 opt-level = 2
 
 [workspace.dependencies]
-deep_space = { version = "2", features = ["althea"], default-features = false }
+deep_space = {version = "2", features = ["althea"], default-features=false}
+web30 = "1.2"
+clarity = "1.3"
+awc = {version = "3.2", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -661,7 +661,7 @@ where
     let s = String::deserialize(deserializer).unwrap_or_default();
     let value: Option<ContactType> = match serde_json::from_str(&s) {
         Ok(value) => value,
-        Err(e) => return Err(e).map_err(D::Error::custom),
+        Err(e) => return Err(D::Error::custom(e)),
     };
     Ok(value)
 }

--- a/antenna_forwarding_client/src/lib.rs
+++ b/antenna_forwarding_client/src/lib.rs
@@ -175,7 +175,6 @@ fn process_messages(
             ForwardingProtocolMessage::ConnectionCloseMessage { stream_id } => {
                 trace!("Got close message for stream {}", stream_id);
                 *last_message = Instant::now();
-                let stream_id = stream_id;
                 if let Some(stream) = streams.get(stream_id) {
                     let _res = stream.stream.shutdown(Shutdown::Both);
                     streams.remove(stream_id);

--- a/antenna_forwarding_client/src/lib.rs
+++ b/antenna_forwarding_client/src/lib.rs
@@ -189,7 +189,6 @@ fn process_messages(
                     payload.len()
                 );
                 *last_message = Instant::now();
-                let stream_id = stream_id;
                 if let Some(antenna_stream) = streams.get_mut(stream_id) {
                     if let Err(e) = write_all_spinlock(&mut antenna_stream.stream, payload) {
                         error!(

--- a/antenna_forwarding_protocol/Cargo.toml
+++ b/antenna_forwarding_protocol/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
 sodiumoxide = "0.2"
+clarity = {workspace = true}
 log = "0.4"
 lazy_static = "1.4"
 

--- a/auto_bridge/Cargo.toml
+++ b/auto_bridge/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Jehan <jehan.tremback@gmail.com>, Justin <justin@althea.net>"]
 edition = "2018"
 
 [dependencies]
-web30 = "1.0"
+web30 = {workspace = true}
 num256 = "0.5"
-clarity = "1.2"
+clarity = {workspace = true}
+rand = "0.8"
+num = "0.4"
 log = "0.4"
 serde_derive = "1.0"
 serde = "1.0"

--- a/auto_bridge/src/lib.rs
+++ b/auto_bridge/src/lib.rs
@@ -119,9 +119,9 @@ impl TokenBridge {
         // You basically just send it some dai to the bridge address and they show
         // up in the same address on the xdai side we have no idea when this has succeeded
         // since the events are not indexed
-        let tx_hash = self
+        let tx = self
             .eth_web3
-            .send_transaction(
+            .prepare_transaction(
                 *DAI_CONTRACT_ON_ETH,
                 encode_call(
                     "transfer(address,uint256)",
@@ -133,6 +133,7 @@ impl TokenBridge {
                 Vec::new(),
             )
             .await?;
+        let tx_hash = self.eth_web3.send_prepared_transaction(tx).await?;
 
         self.eth_web3
             .wait_for_transaction(tx_hash, timeout, None)
@@ -178,9 +179,9 @@ impl TokenBridge {
             bytes_to_hex_str(&payload),
         );
 
-        let txid = self
+        let tx = self
             .eth_web3
-            .send_transaction(
+            .prepare_transaction(
                 self.xdai_bridge_on_eth,
                 payload,
                 0u32.into(),
@@ -188,6 +189,7 @@ impl TokenBridge {
                 Vec::new(),
             )
             .await?;
+        let txid = self.eth_web3.send_prepared_transaction(tx).await?;
 
         let _ = self
             .eth_web3
@@ -369,9 +371,9 @@ pub async fn encode_relaytokens(
     let payload = encode_call("relayTokens(address)", &[dest_address.into()]).unwrap();
     let options = Vec::new();
 
-    let tx_hash = bridge
+    let tx = bridge
         .xdai_web3
-        .send_transaction(
+        .prepare_transaction(
             bridge.xdai_bridge_on_xdai,
             payload,
             amount,
@@ -379,6 +381,7 @@ pub async fn encode_relaytokens(
             options,
         )
         .await?;
+    let tx_hash = bridge.xdai_web3.send_prepared_transaction(tx).await?;
 
     bridge
         .xdai_web3

--- a/clu/Cargo.toml
+++ b/clu/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 ipgen = "1.0.1"
 rand = "0.8"
 serde_json = "1.0"
-clarity = "1.2"
+clarity = {workspace = true}
 sodiumoxide = "0.2"
 deep_space = { workspace = true }
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -26,15 +26,15 @@ rita_db_migration = { path = "../rita_db_migration" }
 ctrlc = { version = "3.2.1", features = ["termination"] }
 diesel = { version = "1.4", features = ["postgres", "r2d2"] }
 diesel_migrations = { version = "1.4", features = ["postgres"] }
-awc = "3.1"
+awc = {workspace = true}
 actix-rt = "2.8"
-deep_space = { workspace = true }
-clarity = "1.2"
+deep_space = {workspace = true}
+clarity = {workspace = true}
 althea_proto = "0.3.0"
 futures = { version = "0.3", features = ["compat"] }
 num256 = "0.5"
-num-traits = "0.2"
-web30 = "1.0"
+num-traits="0.2"
+web30 = {workspace = true}
 lazy_static = "1.4"
 actix-web = { version = "4.3", default_features = false, features = [
     "openssl",

--- a/integration_tests/src/registration_server.rs
+++ b/integration_tests/src/registration_server.rs
@@ -73,7 +73,6 @@ async fn register_router(client: Json<ExitClientIdentity>) -> HttpResponse {
     let db_addr = get_althea_db_addr();
 
     // Check for an existing client
-    let client = client;
     if client_conflict(
         &client,
         &contact,

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -1013,7 +1013,7 @@ pub async fn send_eth_bulk(amount: Uint256, destinations: &[clarity::Address], w
     }
     let mut txids = Vec::new();
     for tx in transactions.iter() {
-        let txid = web3.eth_send_raw_transaction(tx.to_bytes()).await;
+        let txid = web3.send_prepared_transaction(tx.clone()).await;
         info!("{:?}", txid);
         txids.push(txid);
     }

--- a/rita_bin/Cargo.toml
+++ b/rita_bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_bin"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2018"
 license = "Apache-2.0"
 build = "build.rs"

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -27,14 +27,14 @@ phonenumber = "0.3"
 babel_monitor = { path = "../babel_monitor" }
 arrayvec = { version = "0.7", features = ["serde"] }
 sodiumoxide = "0.2"
-web30 = "1.0"
-awc = "3.1"
+clu = { path = "../clu" }
+web30 = {workspace = true}
+awc = {workspace = true}
 ipnetwork = "0.20"
-actix-async = { package = "actix", version = "0.13" }
-actix-web-async = { package = "actix-web", version = "4.3", default_features = false, features = [
-    "openssl",
-] }
-clarity = "1.2"
+actix-async = {package="actix", version = "0.13"}
+actix-web-async = { package="actix-web", version = "4.3", default_features = false, features= ["openssl"]}
+actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.8.0"}
+clarity = {workspace = true}
 openssh-keys = "0.6"
 mac_address = "1.1.4"
 futures = { version = "0.3", features = ["compat"] }

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_client"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_client/src/traffic_watcher/mod.rs
+++ b/rita_client/src/traffic_watcher/mod.rs
@@ -67,7 +67,7 @@ pub fn get_traffic_watcher_write_ref(
     input: &mut HashMap<u32, TrafficWatcher>,
 ) -> &mut TrafficWatcher {
     let netns = KI.check_integration_test_netns();
-    input.entry(netns).or_insert_with(TrafficWatcher::default);
+    input.entry(netns).or_default();
     input.get_mut(&netns).unwrap()
 }
 

--- a/rita_client_registration/src/client_db.rs
+++ b/rita_client_registration/src/client_db.rs
@@ -103,8 +103,8 @@ pub async fn add_client_to_registered_list(
     wait_timeout: Option<Duration>,
     options: Vec<SendTxOption>,
 ) -> Result<Uint256, Web3Error> {
-    let tx_hash = web30
-        .send_transaction(
+    let tx = web30
+        .prepare_transaction(
             contract,
             encode_call(
                 "add_registered_user((string,string,address))",
@@ -119,6 +119,7 @@ pub async fn add_client_to_registered_list(
             options,
         )
         .await?;
+    let tx_hash = web30.send_prepared_transaction(tx).await?;
 
     if let Some(timeout) = wait_timeout {
         future_timeout(timeout, web30.wait_for_transaction(tx_hash, timeout, None)).await??;

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -22,7 +22,7 @@ auto-bridge = { path = "../auto_bridge" }
 serde_json = "1.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 settings = { path = "../settings" }
-clarity = "1.2"
+clarity = {workspace = true}
 futures = { version = "0.3", features = ["compat"] }
 num256 = "0.5"
 num-traits = "0.2"
@@ -30,23 +30,15 @@ bincode = "1.3"
 serde_cbor = "0.11"
 lazy_static = "1.4"
 althea_kernel_interface = { path = "../althea_kernel_interface" }
-actix-web-httpauth-async = { package = "actix-web-httpauth", version = "0.8.0" }
-actix-web-async = { package = "actix-web", version = "4.3", default_features = false, features = [
-    "openssl",
-] }
-awc = { version = "3.1", default-features = false, features = [
-    "openssl",
-    "compress-gzip",
-    "compress-zstd",
-] }
+actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.8.0"}
+actix-web-async = { package="actix-web", version = "4.3", default_features = false, features= ["openssl"]}
+awc = {workspace = true}
 actix-service = "2.0.2"
-web30 = "1.0"
+web30 = {workspace = true}
 althea_types = { path = "../althea_types" }
-deep_space = { workspace = true }
-prost-types = "0.12"
-cosmos-sdk-proto-althea = { package = "cosmos-sdk-proto-althea", version = "0.16", features = [
-    "ethermint",
-] }
+deep_space = {workspace = true}
+prost-types ="0.12"
+cosmos-sdk-proto-althea = {package = "cosmos-sdk-proto-althea", version = "0.16", features = ["ethermint"]} 
 
 [dependencies.regex]
 version = "1.6"

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_common"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_common/src/dashboard/own_info.rs
+++ b/rita_common/src/dashboard/own_info.rs
@@ -7,7 +7,7 @@ use actix_web_async::HttpResponse;
 use clarity::Address;
 use num256::{Int256, Uint256};
 
-pub static READABLE_VERSION: &str = "Beta 21 RC2";
+pub static READABLE_VERSION: &str = "Beta 21 RC3";
 
 #[derive(Serialize)]
 pub struct OwnInfo {

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -66,7 +66,7 @@ pub fn get_debt_keeper() -> DebtKeeper {
 /// but still hold the lock in the local thread to prevent parallel modification
 pub fn get_debt_keeper_write_ref(input: &mut HashMap<u32, DebtKeeper>) -> &mut DebtKeeper {
     let netns = KI.check_integration_test_netns();
-    input.entry(netns).or_insert_with(DebtKeeper::default);
+    input.entry(netns).or_default();
     input.get_mut(&netns).unwrap()
 }
 
@@ -512,9 +512,7 @@ impl DebtKeeper {
     }
 
     fn get_debt_data_mut(&mut self, ident: &Identity) -> &mut NodeDebtData {
-        self.debt_data
-            .entry(*ident)
-            .or_insert_with(NodeDebtData::new)
+        self.debt_data.entry(*ident).or_default()
     }
 
     fn payment_failed(&mut self, to: &Identity) {

--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -61,9 +61,7 @@ pub fn get_payment_controller_write_ref(
     input: &mut HashMap<u32, PaymentController>,
 ) -> &mut PaymentController {
     let netns = KI.check_integration_test_netns();
-    input
-        .entry(netns)
-        .or_insert_with(PaymentController::default);
+    input.entry(netns).or_default();
     input.get_mut(&netns).unwrap()
 }
 
@@ -210,7 +208,7 @@ async fn make_althea_payment(
     // On althea chain, we default to paying with usdc, config must specify this as an accepted denom
     let usdc_denom = match payment_settings
         .accepted_denoms
-        .unwrap_or(HashMap::new())
+        .unwrap_or_default()
         .get("usdc")
     {
         Some(a) => a.clone(),
@@ -402,7 +400,7 @@ async fn make_xdai_payment(
             // add published txid to submission
             let pmt = pmt.publish(tx_id);
 
-            send_make_payment_endpoints(pmt.clone(), network_settings, Some(full_node), None).await;
+            send_make_payment_endpoints(pmt, network_settings, Some(full_node), None).await;
 
             // place this payment in the validation queue to handle later.
             let ts = ToValidate {

--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -89,7 +89,7 @@ pub fn get_payment_validator_write_ref(
     input: &mut HashMap<u32, PaymentValidator>,
 ) -> &mut PaymentValidator {
     let netns = KI.check_integration_test_netns();
-    input.entry(netns).or_insert_with(PaymentValidator::default);
+    input.entry(netns).or_default();
     input.get_mut(&netns).unwrap()
 }
 
@@ -748,7 +748,7 @@ fn handle_tx_messaging_althea(transaction: TransactionDetails, ts: ToValidate) {
     for d in get_rita_common()
         .payment
         .accepted_denoms
-        .unwrap_or(HashMap::new())
+        .unwrap_or_default()
     {
         if transaction.denom == d.1.denom {
             denom = Some(d.1);

--- a/rita_common/src/tunnel_manager/mod.rs
+++ b/rita_common/src/tunnel_manager/mod.rs
@@ -62,7 +62,7 @@ pub fn get_tunnel_manager() -> TunnelManager {
 /// but still hold the lock in the local thread to prevent parallel modification
 pub fn get_tunnel_manager_write_ref(input: &mut HashMap<u32, TunnelManager>) -> &mut TunnelManager {
     let netns = KI.check_integration_test_netns();
-    input.entry(netns).or_insert_with(TunnelManager::default);
+    input.entry(netns).or_default();
     input.get_mut(&netns).unwrap()
 }
 
@@ -695,7 +695,7 @@ pub mod tests {
         tunnel_manager
             .tunnels
             .entry(id)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(get_test_tunnel("0.0.0.0".parse().unwrap()));
         {
             let existing_tunnel =

--- a/rita_common/src/usage_tracker/structs.rs
+++ b/rita_common/src/usage_tracker/structs.rs
@@ -133,7 +133,7 @@ impl Ord for UsageTrackerPayment {
 
 impl PartialOrd for UsageTrackerPayment {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.index.partial_cmp(&other.index)
+        Some(self.index.cmp(&other.index))
     }
 }
 

--- a/rita_common/src/usage_tracker/tests.rs
+++ b/rita_common/src/usage_tracker/tests.rs
@@ -97,7 +97,7 @@ pub mod test {
         assert!(res2 == res4);
     }
 
-    /// tests that the flat conversion comes out in the right order (decreasing usage hours)
+    /// tests that the flat conversion comes out in the right order (increasing usage hours)
     #[test]
     fn check_flat_conversion() {
         let tracker = generate_dummy_usage_tracker();
@@ -105,7 +105,7 @@ pub mod test {
         let mut last: Option<IndexedUsageHour> = None;
         for i in flat {
             if let Some(last) = last {
-                assert!(i.index < last.index)
+                assert!(i.index > last.index)
             }
             last = Some(i)
         }

--- a/rita_exit/Cargo.toml
+++ b/rita_exit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_exit"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_exit/Cargo.toml
+++ b/rita_exit/Cargo.toml
@@ -15,12 +15,12 @@ althea_kernel_interface = { path = "../althea_kernel_interface" }
 althea_types = { path = "../althea_types" }
 settings = { path = "../settings" }
 babel_monitor = { path = "../babel_monitor" }
-actix-async = { package = "actix", version = "0.13" }
-awc = "3.1"
+actix-async = { package = "actix", version = "0.13"}
+awc = {workspace = true}
 handlebars = "4.0"
 lazy_static = "1.4"
 ipnetwork = "0.20"
-clarity = "1.2"
+clarity = {workspace = true}
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/rita_extender/Cargo.toml
+++ b/rita_extender/Cargo.toml
@@ -15,7 +15,7 @@ rita_common = { path = "../rita_common" }
 rita_client = { path = "../rita_client" }
 log = { version = "0.4", features = ["release_max_level_info"] }
 settings = { path = "../settings" }
-awc = "3.1"
+awc = {workspace = true}
 actix-async = {package="actix", version = "0.13"}
 actix-web-async = { package="actix-web", version = "4.3", default_features = false, features= ["openssl"]}
 althea_types = {path = "../althea_types"}

--- a/rita_extender/Cargo.toml
+++ b/rita_extender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_extender"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/settings/Cargo.toml
+++ b/settings/Cargo.toml
@@ -15,8 +15,8 @@ serde_json = "1.0"
 toml = "0.5"
 log = "0.4"
 lazy_static = "1.4"
-clarity = "1.2"
-arrayvec = { version = "0.7", features = ["serde"] }
+clarity = {workspace = true}
+arrayvec = {version= "0.7", features = ["serde"]}
 phonenumber = "0.3"
 ipnetwork = "0.20"
 

--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -11,8 +11,8 @@ path = "src/main.rs"
 env_logger = "0.10"
 log = "0.4"
 docopt = "1.1"
-ctrlc = { version = "3.2.1", features = ["termination"] }
-awc = "3.1"
+ctrlc = {version = "3.2.1", features = ["termination"]}
+awc = {workspace = true}
 actix-rt = "2.8"
 integration_tests = { path = "../integration_tests" }
 althea_types = { path = "../althea_types" }


### PR DESCRIPTION
This patch updates to the latest version of Clarity and Web30 which contain a fix specifically created for this situation.

By separating the prepare and send transaction steps we can more carefully separate cases where we might have published a transaction from those where there is no possibility.

Due to recent strange behavior on Gnosis chain, including reorgs and our own rpc issues routers would repeatedly attempt to send the same payment over and over again, these payments would then successfully enter the chain but return an error to the router, which would simply continue to retry the transaction. Resulting in a wallet draining bug.