### PR TITLE
Overhaul automated rescue options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "rita_bin"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "rita_client"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "actix",
  "actix-web",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "rita_common"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "actix",
  "actix-service",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "rita_exit"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "actix",
  "actix-web",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "rita_extender"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "actix",
  "actix-web",

--- a/althea_kernel_interface/src/hardware_info.rs
+++ b/althea_kernel_interface/src/hardware_info.rs
@@ -449,7 +449,7 @@ fn get_wifi_survey_info(dev: &str) -> Vec<WifiSurveyData> {
             Ok(a) => extract_wifi_survey_data(&a, dev),
             Err(e) => {
                 error!("Unable to parse iw survey dump {:?}", e);
-                return Vec::new();
+                Vec::new()
             }
         },
         Err(e) => {
@@ -469,7 +469,7 @@ fn get_wifi_station_info(dev: &str) -> Vec<WifiStationData> {
             Ok(a) => extract_wifi_station_data(&a),
             Err(e) => {
                 error!("Unable to parse iw station dump {:?}", e);
-                return Vec::new();
+                Vec::new()
             }
         },
         Err(e) => {

--- a/althea_kernel_interface/src/hardware_info.rs
+++ b/althea_kernel_interface/src/hardware_info.rs
@@ -337,28 +337,23 @@ fn get_ethernet_stats() -> Option<Vec<EthernetStats>> {
 }
 
 fn get_wifi_devices() -> Vec<WifiDevice> {
-    let mut ret: Vec<WifiDevice> = Vec::new();
-    //get devices
-    let devices = parse_wifi_device_names();
-    if devices.is_err() {
-        warn!("Unable to get wifi devices: {:?}", devices);
-        return Vec::new();
+    match parse_wifi_device_names() {
+        Ok(devices) => devices
+            .into_iter()
+            .map(|dev| WifiDevice {
+                name: dev.clone(),
+                survey_data: get_wifi_survey_info(&dev),
+                station_data: get_wifi_station_info(&dev),
+                ssid: get_radio_ssid(&dev),
+                channel: get_radio_channel(&dev),
+                enabled: get_radio_enabled(&dev),
+            })
+            .collect(),
+        Err(err) => {
+            warn!("Unable to get wifi devices: {:?}", err);
+            Vec::new()
+        }
     }
-
-    for dev in devices.unwrap() {
-        let device = WifiDevice {
-            name: dev.clone(),
-            survey_data: get_wifi_survey_info(&dev),
-            station_data: get_wifi_station_info(&dev),
-            ssid: get_radio_ssid(&dev),
-            channel: get_radio_channel(&dev),
-            enabled: get_radio_enabled(&dev),
-        };
-        info!("Created the following wifi struct: {:?}", device.clone());
-        ret.push(device);
-    }
-
-    ret
 }
 
 /// This function parses files in /proc that contain conntrack info to send to ops
@@ -449,13 +444,19 @@ fn get_wifi_survey_info(dev: &str) -> Vec<WifiSurveyData> {
         .args([dev, "survey", "dump"])
         .stdout(Stdio::piped())
         .output();
-
-    if res.is_err() {
-        error!("Unable to run survey dump {:?}", res);
-        return Vec::new();
+    match res {
+        Ok(a) => match String::from_utf8(a.stdout) {
+            Ok(a) => extract_wifi_survey_data(&a, dev),
+            Err(e) => {
+                error!("Unable to parse iw survey dump {:?}", e);
+                return Vec::new();
+            }
+        },
+        Err(e) => {
+            error!("Unable to run survey dump {:?}", e);
+            Vec::new()
+        }
     }
-    let res = String::from_utf8(res.unwrap().stdout).unwrap();
-    extract_wifi_survey_data(&res, dev)
 }
 
 fn get_wifi_station_info(dev: &str) -> Vec<WifiStationData> {
@@ -463,14 +464,19 @@ fn get_wifi_station_info(dev: &str) -> Vec<WifiStationData> {
         .args([dev, "station", "dump"])
         .stdout(Stdio::piped())
         .output();
-
-    if res.is_err() {
-        error!("Unable to run station dump {:?}", res);
-        return Vec::new();
+    match res {
+        Ok(a) => match String::from_utf8(a.stdout) {
+            Ok(a) => extract_wifi_station_data(&a),
+            Err(e) => {
+                error!("Unable to parse iw station dump {:?}", e);
+                return Vec::new();
+            }
+        },
+        Err(e) => {
+            error!("Unable to run station dump {:?}", e);
+            Vec::new()
+        }
     }
-
-    let res = String::from_utf8(res.unwrap().stdout).unwrap();
-    extract_wifi_station_data(&res)
 }
 
 /// Expected input wlan0, wlan1, etc

--- a/althea_kernel_interface/src/ping_check.rs
+++ b/althea_kernel_interface/src/ping_check.rs
@@ -5,7 +5,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 impl dyn KernelInterface {
-    //Pings a ipv6 address to determine if it's online
+    //Pings an address to determine if it's online
     pub fn ping_check(
         &self,
         ip: &IpAddr,

--- a/integration_tests/src/setup_utils/rita.rs
+++ b/integration_tests/src/setup_utils/rita.rs
@@ -248,8 +248,6 @@ pub fn spawn_rita_exit(
         resettings.exit_network.exit_price = exit_fee;
         let veth_exit_to_native = format!("vout-{}-o", ns);
         resettings.network.external_nic = Some(veth_exit_to_native);
-        // each exit instance connects to one database in the default net namespace
-        resettings.db_uri = "postgresql://postgres@10.0.0.1/test".to_string();
 
         // mirrored from rita_bin/src/exit.rs
         let resettings = clu::exit_init(resettings);

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -370,7 +370,6 @@ pub fn get_default_settings(
 ) -> (RitaClientSettings, RitaExitSettingsStruct) {
     let mut exit_servers = HashMap::new();
     let mut exit = RitaExitSettingsStruct {
-        db_uri: "postgres://postgres@localhost/test".to_string(),
         client_registration_url: "https://7.7.7.1:40400/register_router".to_string(),
         workers: 2,
         remote_log: false,

--- a/rita_bin/Cargo.toml
+++ b/rita_bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_bin"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2018"
 license = "Apache-2.0"
 build = "build.rs"

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_client"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_client/src/heartbeat/mod.rs
+++ b/rita_client/src/heartbeat/mod.rs
@@ -13,6 +13,7 @@
 //! This packet is encrypted using the usual LibSodium box construction and sent to the heartbeat server in the following format
 //! WgKey, Nonce, Ciphertext for the HeartBeatMessage. This consumes 32 bytes, 24 bytes, and to the end of the message
 
+use althea_kernel_interface::KI;
 use althea_types::ExitDetails;
 
 use babel_monitor::parsing::get_installed_route;
@@ -113,9 +114,8 @@ pub fn send_heartbeat_loop() {
         } {
             error!("Heartbeat loop thread panicked! Respawning {:?}", e);
             if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = actix_async::System::current();
-                sys.stop_with_code(121);
+                error!("Restarting too quickly, rebooting instead!");
+                let _res = KI.run_command("reboot", &[]);
             }
             last_restart = Instant::now();
         }

--- a/rita_client/src/operator_update/update_loop.rs
+++ b/rita_client/src/operator_update/update_loop.rs
@@ -3,6 +3,7 @@
 
 use crate::operator_update::{operator_update, TARGET_UPDATE_FREQUENCY, UPDATE_FREQUENCY_CAP};
 use actix_async::System as AsyncSystem;
+use althea_kernel_interface::KI;
 use rand::Rng;
 use std::cmp::{max, min};
 use std::thread;
@@ -72,9 +73,8 @@ pub fn start_operator_update_loop() {
                 e
             );
             if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
+                error!("Restarting too quickly, rebooting instead!");
+                let _res = KI.run_command("reboot", &[]);
             }
             last_restart = Instant::now();
         }

--- a/rita_client/src/rita_loop/mod.rs
+++ b/rita_client/src/rita_loop/mod.rs
@@ -12,15 +12,18 @@ use crate::heartbeat::HEARTBEAT_SERVER_KEY;
 use crate::operator_fee_manager::tick_operator_payments;
 use crate::InterfaceMode;
 use actix_async::System as AsyncSystem;
+use althea_kernel_interface::hardware_info::get_hardware_info;
 use althea_kernel_interface::KernelInterfaceError;
 use althea_kernel_interface::KI;
 use althea_types::ExitState;
 use antenna_forwarding_client::start_antenna_forwarding_proxy;
+use rand::Rng;
 use rita_common::rita_loop::set_gateway;
 use rita_common::tunnel_manager::tm_get_neighbors;
 use rita_common::usage_tracker::get_current_hour;
 use rita_common::usage_tracker::get_last_saved_usage_hour;
 use settings::client::RitaClientSettings;
+use settings::get_rita_common;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
@@ -30,6 +33,7 @@ use std::io::BufReader;
 use std::io::Read;
 use std::io::Seek;
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -37,7 +41,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 // the speed in seconds for the client loop
-pub const CLIENT_LOOP_SPEED: Duration = Duration::from_secs(5);
+pub const CLIENT_LOOP_SPEED: Duration = Duration::from_secs(30);
 pub const CLIENT_LOOP_TIMEOUT: Duration = Duration::from_secs(4);
 
 lazy_static! {
@@ -85,24 +89,22 @@ pub fn metrics_permitted() -> bool {
             .is_some()
 }
 
-/// Rita loop thread spawning function, there are currently two rita loops, one that
-/// runs as a thread with async/await support and one that runs as a actor using old futures
-/// slowly things will be migrated into this new sync loop as we move to async/await
-pub fn start_rita_loop() {
+/// Rita loop thread spawning function, this function contains all the rita client functions
+/// with the exception of exit operations which have their own loop
+pub fn start_rita_client_loop() {
     let mut last_restart = Instant::now();
 
     // outer thread is a watchdog inner thread is the runner
     thread::spawn(move || {
         // this will always be an error, so it's really just a loop statement
         // with some fancy destructuring
-
         while let Err(e) = {
-            thread::spawn(move || loop {
-                let start = Instant::now();
-                trace!("Client tick!");
+            thread::spawn(move || {
+                let mut last_successful_ping = Instant::now();
+                loop {
+                    let start = Instant::now();
+                    trace!("Client tick!");
 
-                let runner = AsyncSystem::new();
-                runner.block_on(async move {
                     manage_gateway();
                     info!(
                         "Rita Client loop manage gateway in {}s {}ms",
@@ -124,30 +126,41 @@ pub fn start_rita_loop() {
                         start.elapsed().subsec_millis()
                     );
 
-                    // sends an operator payment if enough time has elapsed
-                    tick_operator_payments().await;
+                    last_successful_ping = check_for_rescue_reboot(last_successful_ping);
                     info!(
-                        "Rita Client loop operator payments completed in {}s {}ms",
+                        "Rita Client loop check for rescue reboot completed in {}s {}ms",
                         start.elapsed().as_secs(),
                         start.elapsed().subsec_millis()
                     );
-                });
 
-                info!(
-                    "Rita Client loop completed in {}s {}ms",
-                    start.elapsed().as_secs(),
-                    start.elapsed().subsec_millis()
-                );
+                    // if you have additional async functions to run please add them here
+                    // in order to reuse the runner
+                    let runner = AsyncSystem::new();
+                    runner.block_on(async move {
+                        // sends an operator payment if enough time has elapsed
+                        tick_operator_payments().await;
+                        info!(
+                            "Rita Client loop operator payments completed in {}s {}ms",
+                            start.elapsed().as_secs(),
+                            start.elapsed().subsec_millis()
+                        );
+                    });
 
-                thread::sleep(CLIENT_LOOP_SPEED);
+                    info!(
+                        "Rita Client loop completed in {}s {}ms",
+                        start.elapsed().as_secs(),
+                        start.elapsed().subsec_millis()
+                    );
+
+                    thread::sleep(CLIENT_LOOP_SPEED);
+                }
             })
             .join()
         } {
             error!("Rita client loop thread paniced! Respawning {:?}", e);
             if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
+                error!("Restarting too quickly, rebooting instead!");
+                let _res = KI.run_command("reboot", &[]);
             }
             last_restart = Instant::now();
         }
@@ -159,7 +172,7 @@ pub fn start_rita_client_loops() {
         send_heartbeat_loop();
     }
     crate::exit_manager::exit_loop::start_exit_manager_loop();
-    crate::rita_loop::start_rita_loop();
+    crate::rita_loop::start_rita_client_loop();
     crate::operator_update::update_loop::start_operator_update_loop();
 }
 
@@ -473,4 +486,76 @@ fn maybe_parse_ip(
         Ok(s) => Ok(s.parse()?),
         Err(e) => Err(e),
     }
+}
+
+/// This list should contain as many unique public ips from as many different providers as possible
+/// the larger this list the less we ping any specific provider and the less likely we are to be
+/// confused by a single router being down
+const PING_TEST_IPS: [Ipv4Addr; 6] = [
+    // Cloudflare
+    Ipv4Addr::new(1, 1, 1, 1),
+    // Google
+    Ipv4Addr::new(8, 8, 8, 8),
+    // Quad9
+    Ipv4Addr::new(9, 9, 9, 9),
+    // Hurricane Electric
+    Ipv4Addr::new(74, 82, 42, 42),
+    // OpenDNS
+    Ipv4Addr::new(208, 67, 222, 222),
+    // Verisin
+    Ipv4Addr::new(64, 6, 65, 6),
+];
+/// Verifies ipv4 connectivity by pinging a set list of external ip addresses. This check
+/// comes with some risk, if the ip addresses provided are all down, the router will reboot
+/// even if connectivity to the rest of the internet is fine. To avoid this we ping several
+/// different common addresses
+pub fn run_ping_test() -> bool {
+    let mut rng = rand::thread_rng();
+    let index = rng.gen_range(0..PING_TEST_IPS.len());
+    let target_ip = PING_TEST_IPS[index];
+
+    let timeout = Duration::from_secs(5);
+    match KI.ping_check(&target_ip.into(), timeout, None) {
+        Ok(out) => out,
+        Err(e) => {
+            error!("ipv4 ping error: {:?}", e);
+            false
+        }
+    }
+}
+
+const PING_TEST_SPEED: Duration = Duration::from_secs(100);
+const REBOOT_TIMEOUT: Duration = Duration::from_secs(600);
+/// This function checks if the router needs a rescue reboot. Meaning it has entered a bad state somehow and needs to be restarted
+/// to recover.
+fn check_for_rescue_reboot(mut last_successful_ping: Instant) -> Instant {
+    // first we check if we can reach the internet, if we can't for too long we reboot
+
+    // Run this ping test every PING_TEST_SPEED seconds
+    if Instant::now() - last_successful_ping > PING_TEST_SPEED {
+        if run_ping_test() {
+            last_successful_ping = Instant::now();
+        } else {
+            // If this router has been in a bad state for >10 mins, reboot
+            if (Instant::now() - last_successful_ping) > REBOOT_TIMEOUT {
+                let _res = KI.run_command("reboot", &[]);
+            }
+        }
+    }
+
+    // next we check if the load average is too high for hAP specifically since they are more prone to this
+    let model = get_rita_common().network.device;
+    let hw_info = get_hardware_info(model.clone());
+    match (model, hw_info) {
+        (None, _) => error!("Model name not found?"),
+        (Some(mdl), Ok(info)) => {
+            if mdl.contains("mikrotik_hap-ac2") && info.load_avg_fifteen_minute > 4.0 {
+                info!("15 minute load average > 4, rebooting!");
+                let _res = KI.run_command("reboot", &[]);
+            }
+        }
+        (Some(_), Err(_)) => error!("Could not get hardware info!"),
+    }
+
+    last_successful_ping
 }

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_common"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_common/src/dashboard/own_info.rs
+++ b/rita_common/src/dashboard/own_info.rs
@@ -7,7 +7,7 @@ use actix_web_async::HttpResponse;
 use clarity::Address;
 use num256::{Int256, Uint256};
 
-pub static READABLE_VERSION: &str = "Beta 21 RC3";
+pub static READABLE_VERSION: &str = "Beta 21 RC4";
 
 #[derive(Serialize)]
 pub struct OwnInfo {

--- a/rita_common/src/rita_loop/fast_loop.rs
+++ b/rita_common/src/rita_loop/fast_loop.rs
@@ -9,6 +9,7 @@ use crate::peer_listener::structs::PeerListener;
 use crate::traffic_watcher::watch;
 use crate::tunnel_manager::contact_peers::tm_contact_peers;
 use crate::tunnel_manager::tm_get_neighbors;
+use crate::KI;
 use actix_async::System as AsyncSystem;
 use babel_monitor::open_babel_stream;
 use babel_monitor::parse_neighs;
@@ -107,11 +108,13 @@ pub fn start_rita_fast_loop() {
             })
             .join()
         } {
-            error!("Rita common fast loop thread paniced! Respawning {:?}", e);
+            error!("Rita common fast loop thread panicked! Respawning {:?}", e);
             if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
+                error!("Restarting too quickly, rebooting instead!");
+                // only reboot if we are on openwrt, otherwise we are probably on a datacenter server rebooting that is a bad idea
+                if KI.is_openwrt() {
+                    let _res = KI.run_command("reboot", &[]);
+                }
             }
             last_restart = Instant::now();
         }
@@ -171,9 +174,11 @@ pub fn peer_discovery_loop() {
                 e
             );
             if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
+                error!("Restarting too quickly, rebooting instead!");
+                // only reboot if we are on openwrt, otherwise we are probably on a datacenter server rebooting that is a bad idea
+                if KI.is_openwrt() {
+                    let _res = KI.run_command("reboot", &[]);
+                }
             }
             last_restart = Instant::now();
         }

--- a/rita_common/src/rita_loop/slow_loop.rs
+++ b/rita_common/src/rita_loop/slow_loop.rs
@@ -4,13 +4,11 @@ use crate::token_bridge::tick_token_bridge;
 use crate::tunnel_manager::tm_common_slow_loop_helper;
 use crate::KI;
 use actix_async::System as AsyncSystem;
-use althea_kernel_interface::hardware_info::get_hardware_info;
 use babel_monitor::open_babel_stream;
 use babel_monitor::parse_interfaces;
 use babel_monitor::set_local_fee;
 use babel_monitor::set_metric_factor;
 use babel_monitor::structs::BabelMonitorError;
-use settings::get_rita_common;
 use std::net::TcpStream;
 use std::thread;
 use std::time::Duration;
@@ -34,8 +32,6 @@ pub fn start_rita_slow_loop() {
             thread::spawn(move || loop {
                 info!("Common Slow tick!");
                 let start = Instant::now();
-
-               check_for_hap_reboot();
 
                 // checks for and updates tunnel manager traffic shaper values
                 handle_shaping();
@@ -106,30 +102,15 @@ pub fn start_rita_slow_loop() {
         } {
             error!("Rita common slow loop thread panicked! Respawning {:?}", e);
             if Instant::now() - last_restart < Duration::from_secs(120) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
+                error!("Restarting too quickly, rebooting instead!");
+                // only reboot if we are on openwrt, otherwise we are probably on a datacenter server rebooting that is a bad idea
+                if KI.is_openwrt() {
+                    let _res = KI.run_command("reboot", &[]);
+                }
             }
             last_restart = Instant::now();
         }
     });
-}
-
-/// This is a special handler for hAP routers which have a habit of getting locked up in
-/// runway cpu use cases, restarting them usually resolves it
-fn check_for_hap_reboot() {
-    let model = get_rita_common().network.device;
-    let hw_info = get_hardware_info(model.clone());
-    match (model, hw_info) {
-        (None, _) => error!("Model name not found?"),
-        (Some(mdl), Ok(info)) => {
-            if mdl.contains("mikrotik_hap-ac2") && info.load_avg_fifteen_minute > 4.0 {
-                info!("15 minute load average > 4, rebooting!");
-                let _res = KI.run_command("reboot", &[]);
-            }
-        }
-        (Some(_), Err(_)) => error!("Could not get hardware info!"),
-    }
 }
 
 fn set_babel_price(stream: &mut TcpStream) -> Result<(), BabelMonitorError> {

--- a/rita_exit/Cargo.toml
+++ b/rita_exit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_exit"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_exit/src/operator_update/update_loop.rs
+++ b/rita_exit/src/operator_update/update_loop.rs
@@ -3,11 +3,10 @@
 use crate::operator_update::{operator_update, UPDATE_FREQUENCY};
 use actix_async::System as AsyncSystem;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// This function spawns a thread soley responsible for performing the operator update
 pub fn start_operator_update_loop() {
-    let mut last_restart = Instant::now();
     let rita_started = Instant::now();
     // outer thread is a watchdog inner thread is the runner
     thread::spawn(move || {
@@ -39,12 +38,6 @@ pub fn start_operator_update_loop() {
                 "Rita exit Operator Update loop thread paniced! Respawning {:?}",
                 e
             );
-            if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to auto rescue!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
-            }
-            last_restart = Instant::now();
         }
     });
 }

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -76,7 +76,6 @@ pub type ExitLock = Arc<RwLock<HashMap<WgKey, WgUsage>>>;
 /// thread which simply restarts the billing.
 pub fn start_rita_exit_loop() {
     setup_exit_wg_tunnel();
-    let mut last_restart = Instant::now();
 
     // the last usage of the wg tunnels, if an innner thread restarts this must be preserved to prevent
     // overbilling users
@@ -103,12 +102,6 @@ pub fn start_rita_exit_loop() {
             .join()
         } {
             error!("Exit loop thread panicked! Respawning {:?}", e);
-            if Instant::now() - last_restart < Duration::from_secs(60) {
-                error!("Restarting too quickly, leaving it to systemd!");
-                let sys = AsyncSystem::current();
-                sys.stop_with_code(121);
-            }
-            last_restart = Instant::now();
         }
     });
 }

--- a/rita_extender/Cargo.toml
+++ b/rita_extender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_extender"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -155,8 +155,6 @@ pub struct EmailVerifSettings {
 /// This is the main settings struct for rita_exit
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct RitaExitSettingsStruct {
-    /// starts with file:// or postgres://username:password@localhost/diesel_demo
-    pub db_uri: String,
     /// url exit uses to request a clients registration
     #[serde(default = "default_reg_url")]
     pub client_registration_url: String,
@@ -186,7 +184,6 @@ impl RitaExitSettingsStruct {
     /// default trait to prevent some future code from picking up on the 'default' implementation
     pub fn test_default() -> Self {
         RitaExitSettingsStruct {
-            db_uri: "".to_string(),
             client_registration_url: "".to_string(),
             workers: 1,
             remote_log: false,


### PR DESCRIPTION
This patch represents a complete overhaul of the automated rescue
systems in rita

1) everywhere where we used to try and crash actix to force a restart,
   we instead do a system reboot. Logs show these rescue functions are
   invoked pretty often, but killing the actix thread does not actually
   stop Rita like was originally hoped leaving routers in a bad state

2) The ping check that's used to reboot client routers when they can't
   reach the internet has been overhauld to ping a lot more destinations
   and combined with the hAP overload check

For (1) I've been looking for the reason routers would simply stop opening
tunnels and operating correctly. Reviewing this broken loop rescue
behavior seems like a smoking gun for that sort of bug.