### PR TITLE
Remove installation date from installation details

### DIFF
--- a/althea_types/src/user_info.rs
+++ b/althea_types/src/user_info.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, VecDeque};
 use std::net::Ipv4Addr;
-use std::time::SystemTime;
 
 /// Contains all the data you need for an American mailing address
 /// hopefully also compatible with a few other countries
@@ -58,9 +57,6 @@ pub struct InstallationDetails {
     /// Description of the installation and equipment at the
     /// location
     pub equipment_details: String,
-    /// Time of install, this is set by the operator tools when it accepts
-    /// the value because the router system clocks may be problematic.
-    pub install_date: Option<SystemTime>,
 }
 
 /// The old storage method for usage tracker data that stores flat data

--- a/rita_client/src/dashboard/installation_details.rs
+++ b/rita_client/src/dashboard/installation_details.rs
@@ -93,7 +93,6 @@ pub async fn set_installation_details(req: Json<InstallationDetailsPost>) -> Htt
         relay_antennas: parsed_relay_antenna_ips,
         physical_address: input.physical_address,
         equipment_details: input.equipment_details,
-        install_date: None,
     };
     let new_billing_details = BillingDetails {
         user_first_name: input.first_name,


### PR DESCRIPTION
This same information is better handled in existing DeviceEntry field first_seen in ops and is hanging around doing nothing here.