### PR TITLE
Always rebuild smart contracts when starting chains

### DIFF
--- a/scripts/integration_tests/container_scripts/reload-code.sh
+++ b/scripts/integration_tests/container_scripts/reload-code.sh
@@ -14,7 +14,14 @@ do
     rm -rf "/validator$i"
 done
 
+# setup the solidity contracts
+pushd /althea_rs/solidity/
+npm install .
+npm run typechain
+popd
+# setup validators
 /althea_rs/scripts/integration_tests/container_scripts/setup-validators.sh $NODES
+# run the validators and keep the running in the background
 /althea_rs/scripts/integration_tests/container_scripts/run-testnet.sh $NODES
 
 sleep 10


### PR DESCRIPTION
When running the start chains script we should always rebuild the node environment since it seems to be blown away when moving across branches, causing the tests to fail in unexpected ways and provide no clear message that the npm build is the cause.