### PR TITLE
Lock free payment validator refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,10 +948,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2856,6 +2897,7 @@ dependencies = [
  "actix-web",
  "actix-web-httpauth",
  "althea_kernel_interface",
+ "althea_proto",
  "althea_types",
  "arrayvec",
  "auto-bridge",
@@ -2867,6 +2909,7 @@ dependencies = [
  "clarity",
  "compressed_log",
  "cosmos-sdk-proto-althea",
+ "crossbeam",
  "deep_space",
  "env_logger 0.11.3",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ deep_space = {version = "2", features = ["althea"], default-features=false}
 web30 = "1.2"
 clarity = "1.3"
 awc = {version = "3.2", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}
+althea_proto = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ inherits = "dev"
 opt-level = 2
 
 [workspace.dependencies]
-deep_space = {version = "2", features = ["althea"], default-features=false}
+deep_space = {version = "2.24", features = ["althea"], default-features=false}
 web30 = "1.2"
 clarity = "1.3"
 awc = {version = "3.2", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -16,7 +16,6 @@ use std::fmt;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
-use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
@@ -387,21 +386,6 @@ pub struct LocalIdentity {
     pub wg_port: u16,
     pub have_tunnel: Option<bool>, // If we have an existing tunnel, None if we don't know
     pub global: Identity,
-}
-
-/// This is all the data a light client needs to open a light client tunnel
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct LightClientLocalIdentity {
-    pub wg_port: u16,
-    /// If we have an existing tunnel, None if we don't know
-    pub have_tunnel: Option<bool>,
-    pub global: Identity,
-    /// we have to replicate dhcp ourselves due to the android vpn api
-    pub tunnel_address: Ipv4Addr,
-    /// the local_fee of the node passing light client traffic, much bigger
-    /// than the actual babel price field for ergonomics around downcasting
-    /// the number after upcasting when we compute it.
-    pub price: u128,
 }
 
 /// This represents a generic payment that may be to or from us

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -30,7 +30,7 @@ awc = {workspace = true}
 actix-rt = "2.8"
 deep_space = {workspace = true}
 clarity = {workspace = true}
-althea_proto = "0.6.0"
+althea_proto = {workspace = true}
 futures = { version = "0.3", features = ["compat"] }
 num256 = "0.5"
 num-traits="0.2"

--- a/integration_tests/src/debts.rs
+++ b/integration_tests/src/debts.rs
@@ -273,7 +273,7 @@ pub fn validate_debt_increase(
     let actual_debt_to = debt_entry.payment_details.debt - existing_debt_entry.payment_details.debt;
     let expected_debt_to = bytes_per_gb * data_sent.into() * weight.into() * Int256::from(-1i32);
     info!(
-        "debt now is {:?}, exiting is {:?}",
+        "debt now is {:?}, expected is {:?}",
         debt_entry.payment_details.debt, existing_debt_entry.payment_details.debt
     );
     // Expected and actual debt should be within 75% accurate

--- a/integration_tests/src/five_nodes.rs
+++ b/integration_tests/src/five_nodes.rs
@@ -75,49 +75,51 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     */
     let testa = Namespace {
         id: 1,
-        cost: 25,
+        // two and a half cents / gb in wei / byte
+        cost: 25_000_000,
         node_type: NodeType::Client {
             exit_name: "test_4".to_string(),
         },
     };
     let testb = Namespace {
         id: 2,
-        cost: 500,
+        // 20 cents / gb in wei / byte
+        cost: 500_000_000,
         node_type: NodeType::Client {
             exit_name: "test_4".to_string(),
         },
     };
     let testc = Namespace {
         id: 3,
-        cost: 15,
+        cost: 15_000_000,
         node_type: NodeType::Client {
             exit_name: "test_4".to_string(),
         },
     };
     let testd = Namespace {
         id: 4,
-        cost: 10,
+        cost: 10_000_000,
         node_type: NodeType::Exit {
             instance_name: "test_4".to_string(),
         },
     };
     let teste = Namespace {
         id: 5,
-        cost: 40,
+        cost: 40_000_000,
         node_type: NodeType::Client {
             exit_name: "test_4".to_string(),
         },
     };
     let testf = Namespace {
         id: 6,
-        cost: 20,
+        cost: 20_000_000,
         node_type: NodeType::Client {
             exit_name: "test_4".to_string(),
         },
     };
     let testg = Namespace {
         id: 7,
-        cost: 15,
+        cost: 15_000_000,
         node_type: NodeType::Client {
             exit_name: "test_4".to_string(),
         },
@@ -152,10 +154,34 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
         destination: [
             (2, PriceId { price: 0, id: 2 }),
             (3, PriceId { price: 0, id: 3 }),
-            (4, PriceId { price: 35, id: 3 }),
-            (5, PriceId { price: 15, id: 3 }),
-            (6, PriceId { price: 15, id: 3 }),
-            (7, PriceId { price: 45, id: 3 }),
+            (
+                4,
+                PriceId {
+                    price: 35_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                5,
+                PriceId {
+                    price: 15_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                6,
+                PriceId {
+                    price: 15_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                7,
+                PriceId {
+                    price: 45_000_000,
+                    id: 3,
+                },
+            ),
         ]
         .iter()
         .cloned()
@@ -164,11 +190,35 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     let testb_routes = RouteHop {
         destination: [
             (1, PriceId { price: 0, id: 1 }),
-            (3, PriceId { price: 25, id: 1 }),
+            (
+                3,
+                PriceId {
+                    price: 25_000_000,
+                    id: 1,
+                },
+            ),
             (4, PriceId { price: 0, id: 4 }),
-            (5, PriceId { price: 40, id: 1 }),
-            (6, PriceId { price: 10, id: 4 }),
-            (7, PriceId { price: 10, id: 4 }),
+            (
+                5,
+                PriceId {
+                    price: 40_000_000,
+                    id: 1,
+                },
+            ),
+            (
+                6,
+                PriceId {
+                    price: 10_000_000,
+                    id: 4,
+                },
+            ),
+            (
+                7,
+                PriceId {
+                    price: 10_000_000,
+                    id: 4,
+                },
+            ),
         ]
         .iter()
         .cloned()
@@ -177,11 +227,29 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     let testc_routes = RouteHop {
         destination: [
             (1, PriceId { price: 0, id: 1 }),
-            (2, PriceId { price: 25, id: 1 }),
-            (4, PriceId { price: 20, id: 6 }),
+            (
+                2,
+                PriceId {
+                    price: 25_000_000,
+                    id: 1,
+                },
+            ),
+            (
+                4,
+                PriceId {
+                    price: 20_000_000,
+                    id: 6,
+                },
+            ),
             (5, PriceId { price: 0, id: 5 }),
             (6, PriceId { price: 0, id: 6 }),
-            (7, PriceId { price: 30, id: 6 }),
+            (
+                7,
+                PriceId {
+                    price: 30_000_000,
+                    id: 6,
+                },
+            ),
         ]
         .iter()
         .cloned()
@@ -189,10 +257,28 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     };
     let testd_routes = RouteHop {
         destination: [
-            (1, PriceId { price: 35, id: 6 }),
+            (
+                1,
+                PriceId {
+                    price: 35_000_000,
+                    id: 6,
+                },
+            ),
             (2, PriceId { price: 0, id: 2 }),
-            (3, PriceId { price: 20, id: 6 }),
-            (5, PriceId { price: 35, id: 6 }),
+            (
+                3,
+                PriceId {
+                    price: 20_000_000,
+                    id: 6,
+                },
+            ),
+            (
+                5,
+                PriceId {
+                    price: 35_000_000,
+                    id: 6,
+                },
+            ),
             (6, PriceId { price: 0, id: 6 }),
             (7, PriceId { price: 0, id: 7 }),
         ]
@@ -202,12 +288,42 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     };
     let teste_routes = RouteHop {
         destination: [
-            (1, PriceId { price: 15, id: 3 }),
-            (2, PriceId { price: 40, id: 3 }),
+            (
+                1,
+                PriceId {
+                    price: 15_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                2,
+                PriceId {
+                    price: 40_000_000,
+                    id: 3,
+                },
+            ),
             (3, PriceId { price: 0, id: 3 }),
-            (4, PriceId { price: 35, id: 3 }),
-            (6, PriceId { price: 15, id: 3 }),
-            (7, PriceId { price: 45, id: 3 }),
+            (
+                4,
+                PriceId {
+                    price: 35_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                6,
+                PriceId {
+                    price: 15_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                7,
+                PriceId {
+                    price: 45_000_000,
+                    id: 3,
+                },
+            ),
         ]
         .iter()
         .cloned()
@@ -215,12 +331,36 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     };
     let testf_routes = RouteHop {
         destination: [
-            (1, PriceId { price: 15, id: 3 }),
-            (2, PriceId { price: 10, id: 4 }),
+            (
+                1,
+                PriceId {
+                    price: 15_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                2,
+                PriceId {
+                    price: 10_000_000,
+                    id: 4,
+                },
+            ),
             (3, PriceId { price: 0, id: 3 }),
             (4, PriceId { price: 0, id: 4 }),
-            (5, PriceId { price: 15, id: 3 }),
-            (7, PriceId { price: 10, id: 4 }),
+            (
+                5,
+                PriceId {
+                    price: 15_000_000,
+                    id: 3,
+                },
+            ),
+            (
+                7,
+                PriceId {
+                    price: 10_000_000,
+                    id: 4,
+                },
+            ),
         ]
         .iter()
         .cloned()
@@ -228,12 +368,42 @@ pub fn five_node_config() -> (NamespaceInfo, HashMap<Namespace, RouteHop>) {
     };
     let testg_routes = RouteHop {
         destination: [
-            (1, PriceId { price: 45, id: 4 }),
-            (2, PriceId { price: 10, id: 4 }),
-            (3, PriceId { price: 30, id: 4 }),
+            (
+                1,
+                PriceId {
+                    price: 45_000_000,
+                    id: 4,
+                },
+            ),
+            (
+                2,
+                PriceId {
+                    price: 10_000_000,
+                    id: 4,
+                },
+            ),
+            (
+                3,
+                PriceId {
+                    price: 30_000_000,
+                    id: 4,
+                },
+            ),
             (4, PriceId { price: 0, id: 4 }),
-            (5, PriceId { price: 45, id: 4 }),
-            (6, PriceId { price: 10, id: 4 }),
+            (
+                5,
+                PriceId {
+                    price: 45_000_000,
+                    id: 4,
+                },
+            ),
+            (
+                6,
+                PriceId {
+                    price: 10_000_000,
+                    id: 4,
+                },
+            ),
         ]
         .iter()
         .cloned()

--- a/integration_tests/src/payments_althea.rs
+++ b/integration_tests/src/payments_althea.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-use std::thread;
-use std::time::Duration;
-
 use crate::five_nodes::five_node_config;
 use crate::registration_server::start_registration_server;
 use crate::setup_utils::namespaces::*;
@@ -18,6 +14,8 @@ use deep_space::{EthermintPrivateKey, PrivateKey};
 use rita_common::debt_keeper::GetDebtsResult;
 use settings::client::RitaClientSettings;
 use settings::exit::RitaExitSettingsStruct;
+use std::thread;
+use std::time::Duration;
 
 const USDC_TO_WEI_DECIMAL: u64 = 1_000_000_000_000u64;
 
@@ -136,22 +134,20 @@ fn althea_payments_map(
     c_set: &mut RitaClientSettings,
     exit_set: &mut RitaExitSettingsStruct,
 ) -> (RitaClientSettings, RitaExitSettingsStruct) {
-    let mut accept_de = HashMap::new();
-    accept_de.insert(
-        "usdc".to_string(),
-        Denom {
-            denom: "uUSDC".to_string(),
-            decimal: 1_000_000u64,
-        },
-    );
+    let denom = Denom {
+        denom: "uUSDC".to_string(),
+        decimal: 1_000_000u64,
+    };
 
     c_set.payment.system_chain = SystemChain::Althea;
     exit_set.payment.system_chain = SystemChain::Althea;
     // set pay thres to a smaller value
     c_set.payment.payment_threshold = TEST_PAY_THRESH.into();
     exit_set.payment.payment_threshold = TEST_PAY_THRESH.into();
-    c_set.payment.accepted_denoms = Some(accept_de.clone());
-    exit_set.payment.accepted_denoms = Some(accept_de.clone());
+    c_set.payment.althea_l1_accepted_denoms = vec![denom.clone()];
+    c_set.payment.althea_l1_payment_denom = denom.clone();
+    exit_set.payment.althea_l1_accepted_denoms = vec![denom.clone()];
+    exit_set.payment.althea_l1_payment_denom = denom;
 
     (c_set.clone(), exit_set.clone())
 }

--- a/integration_tests/src/payments_eth.rs
+++ b/integration_tests/src/payments_eth.rs
@@ -94,7 +94,7 @@ pub async fn run_eth_payments_test_scenario() {
     generate_traffic(
         from_node.clone().unwrap(),
         end_node.clone(),
-        "1G".to_string(),
+        "10G".to_string(),
     );
 
     validate_debt_entry(

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -74,7 +74,12 @@ pub const NODE_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(7, 7, 7, 2));
 pub const STAKING_TOKEN: &str = "aalthea";
 pub const MIN_GLOBAL_FEE_AMOUNT: u128 = 10;
 pub const TOTAL_TIMEOUT: Duration = Duration::from_secs(300);
-pub const DEBT_ACCURACY_THRES: u8 = 15;
+/// The maximum difference between routers in the debts test, keep in mind that
+/// due to race conditions this has to be decently large to avoid false positives
+/// as debts will only be exactly the same once the speedtest has completed and
+/// both sides have had time to handle their accounting loops, you'll observe that
+/// accuracy is the worst immediately following the iperf3 and then trends to 100% accurate
+pub const DEBT_ACCURACY_THRES: u8 = 20;
 pub const ETH_NODE: &str = "http://localhost:8545";
 pub const REGISTRATION_SERVER_KEY: &str =
     "0x34d97aaf58b1a81d3ed3068a870d8093c6341cf5d1ef7e6efa03fe7f7fc2c3a8";

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -786,6 +786,8 @@ pub async fn execute_register_coin_proposal(
     keys: &[ValidatorKeys],
     timeout: Option<Duration>,
     coin_params: RegisterCoinProposalParams,
+    // true if we should wait for the proposal to execute
+    wait: bool
 ) {
     let duration = match timeout {
         Some(dur) => dur,
@@ -810,7 +812,9 @@ pub async fn execute_register_coin_proposal(
     info!("Gov proposal executed with {:?}", res.raw_log);
 
     vote_yes_on_proposals(contact, keys, None).await;
-    wait_for_proposals_to_execute(contact).await;
+    if wait {
+        wait_for_proposals_to_execute(contact).await;
+    }
 }
 
 fn parse_phrases(filename: &str) -> (Vec<CosmosPrivateKey>, Vec<String>) {
@@ -852,7 +856,7 @@ pub fn get_keys() -> Vec<ValidatorKeys> {
     ret
 }
 
-pub async fn register_erc20_usdc_token() {
+pub async fn register_erc20_usdc_token(wait: bool) {
     let althea_contact = Contact::new(
         &get_althea_grpc(),
         ALTHEA_CONTACT_TIMEOUT,
@@ -883,6 +887,7 @@ pub async fn register_erc20_usdc_token() {
         &get_keys(),
         Some(TOTAL_TIMEOUT),
         coin_params,
+        wait,
     )
     .await;
 }

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -427,15 +427,12 @@ pub fn althea_system_chain_client(settings: RitaClientSettings) -> RitaClientSet
     let mut settings = settings;
     settings.payment.system_chain = SystemChain::Althea;
     settings.payment.payment_threshold = TEST_PAY_THRESH.into();
-    let mut accept_de = HashMap::new();
-    accept_de.insert(
-        "usdc".to_string(),
-        Denom {
-            denom: "uUSDC".to_string(),
-            decimal: 1_000_000u64,
-        },
-    );
-    settings.payment.accepted_denoms = Some(accept_de);
+    let denom = Denom {
+        denom: "uUSDC".to_string(),
+        decimal: 1_000_000u64,
+    };
+    settings.payment.althea_l1_payment_denom = denom.clone();
+    settings.payment.althea_l1_accepted_denoms = vec![denom];
     settings
 }
 
@@ -445,15 +442,12 @@ pub fn althea_system_chain_exit(settings: RitaExitSettingsStruct) -> RitaExitSet
 
     // set pay thres to a smaller value
     settings.payment.payment_threshold = TEST_PAY_THRESH.into();
-    let mut accept_de = HashMap::new();
-    accept_de.insert(
-        "usdc".to_string(),
-        Denom {
-            denom: "uUSDC".to_string(),
-            decimal: 1_000_000u64,
-        },
-    );
-    settings.payment.accepted_denoms = Some(accept_de);
+    let denom = Denom {
+        denom: "uUSDC".to_string(),
+        decimal: 1_000_000u64,
+    };
+    settings.payment.althea_l1_payment_denom = denom.clone();
+    settings.payment.althea_l1_accepted_denoms = vec![denom];
     settings
 }
 
@@ -914,6 +908,7 @@ pub async fn send_althea_tokens(addresses: Vec<AltheaAddress>) {
                 None,
                 router_address,
                 Some(Duration::from_secs(30)),
+                None,
                 get_althea_evm_priv(),
             )
             .await;
@@ -931,6 +926,7 @@ pub async fn send_althea_tokens(addresses: Vec<AltheaAddress>) {
                 None,
                 router_address,
                 Some(Duration::from_secs(30)),
+                None,
                 get_althea_evm_priv(),
             )
             .await;

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -64,8 +64,8 @@ use web30::{client::Web3, jsonrpc::error::Web3Error, types::SendTxOption};
 const REACHABILITY_TEST_TIMEOUT: Duration = Duration::from_secs(600);
 /// How long the reacability test should wait in between tests
 const REACHABILITY_TEST_CHECK_SPEED: Duration = Duration::from_secs(5);
-/// Pay thresh used in payment tests
-pub const TEST_PAY_THRESH: u64 = 10_000_000_000u64;
+/// Pay thresh used in payment tests, 3c in wei
+pub const TEST_PAY_THRESH: u64 = 30_000_000_000_000_000u64;
 
 pub const OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -787,7 +787,7 @@ pub async fn execute_register_coin_proposal(
     timeout: Option<Duration>,
     coin_params: RegisterCoinProposalParams,
     // true if we should wait for the proposal to execute
-    wait: bool
+    wait: bool,
 ) {
     let duration = match timeout {
         Some(dur) => dur,

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -39,6 +39,8 @@ althea_types = { path = "../althea_types" }
 deep_space = {workspace = true}
 prost-types ="0.12"
 cosmos-sdk-proto-althea = {package = "cosmos-sdk-proto-althea", version = "0.16", features = ["ethermint"]} 
+althea_proto = {workspace = true}
+crossbeam = "0.8"
 
 [dependencies.regex]
 version = "1.6"

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -11,7 +11,7 @@
 use crate::blockchain_oracle::calculate_close_thresh;
 use crate::blockchain_oracle::get_pay_thresh;
 use crate::blockchain_oracle::potential_payment_issues_detected;
-use crate::payment_validator::PAYMENT_SEND_TIMEOUT;
+use crate::payment_validator::ETH_PAYMENT_SEND_TIMEOUT;
 use crate::simulated_txfee_manager::add_tx_to_total;
 use crate::tunnel_manager::tm_tunnel_state_change;
 use crate::tunnel_manager::TunnelAction;
@@ -735,7 +735,7 @@ impl DebtKeeper {
                 // But for the sake of parinoia we provide a handler here which will time out in such a situation
                 match debt_data.payment_in_flight_start {
                     Some(start_time) => {
-                        if Instant::now() - start_time > PAYMENT_SEND_TIMEOUT {
+                        if Instant::now() - start_time > ETH_PAYMENT_SEND_TIMEOUT {
                             error!("Payment in flight for more than payment timeout! Resetting!");
                             debt_data.payment_in_flight = false;
                             debt_data.payment_in_flight_start = None;

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -45,6 +45,16 @@ lazy_static! {
     static ref DEBT_DATA: Arc<RwLock<HashMap<u32,DebtKeeper>>> = Arc::new(RwLock::new(HashMap::new()));
 }
 
+/// Returns the default denomination for the debt keeper
+/// this is used for all internal bandwidth accounting becuase it provides the highest
+/// level of precision which is importnat when communicating prices through babel
+pub fn wei_denom() -> Denom {
+    Denom {
+        denom: DEBT_KEEPER_DENOM.to_string(),
+        decimal: DEBT_KEEPER_DENOM_DECIMAL,
+    }
+}
+
 /// Gets DebtKeeper copy from the static ref, or default if no value has been set
 pub fn get_debt_keeper() -> DebtKeeper {
     let netns = KI.check_integration_test_netns();
@@ -216,7 +226,11 @@ pub fn payment_received(
     dk.payment_received(&from, amount)
 }
 
-/// Currency conversion from_denom -> to_denom
+/// Currency conversion from_denom -> to_denom, this is required for any target chain or token with less than
+/// 18 decimals of precision. Take for example USDC on Althea L1, it has 6 decimals of precision, but the way
+/// we specify bandwidth prices in the babel protocol is smallest unit of payment / byte (smallest unit of billed data)
+/// with a 6 decimal token that's a minimum bandwidth price of $1000/GB so totally unusable. We need to scale up the internal
+/// accounting to deal with wei (18 decimals) only then scale it back down on payment out
 pub fn normalize_payment_amount(amount: Uint256, from_denom: Denom, to_denom: Denom) -> Uint256 {
     let mut amount = amount;
     if from_denom.denom != to_denom.denom {
@@ -227,8 +241,7 @@ pub fn normalize_payment_amount(amount: Uint256, from_denom: Denom, to_denom: De
                 amount, to_denom.decimal
             ),
         };
-        // Pay 1 more unit amount to account for loss from integer division
-        amount = (unit_factor / from_denom.decimal.into()) + 1u64.into();
+        amount = unit_factor / from_denom.decimal.into();
     };
     amount
 }
@@ -1408,5 +1421,21 @@ mod tests {
         // let reader = BufReader::new(File::open(file_path).unwrap());
         // let mut x: Vec<(Identity, NodeDebtData)> = deserialize_from(reader).unwrap();
         // println!("{:?}", x);
+    }
+
+    #[test]
+    fn test_normalize_payment_amount() {
+        // this is $6 in a 6 decimal of precision token where 1 unit = $1
+        let start_amount = Uint256::from(6_000_000u64);
+        // this is $6 in a 18 decimal of precision token where 1 unit = $1
+        let end_amount = Uint256::from(6_000_000_000_000_000_000u64);
+        let usdc = Denom {
+            denom: "uUSDC".to_string(),
+            decimal: 1_000_000,
+        };
+        let res = normalize_payment_amount(start_amount, usdc.clone(), wei_denom());
+        assert_eq!(res, end_amount);
+        let res = normalize_payment_amount(end_amount, wei_denom(), usdc);
+        assert_eq!(res, start_amount)
     }
 }

--- a/rita_common/src/network_endpoints/mod.rs
+++ b/rita_common/src/network_endpoints/mod.rs
@@ -20,6 +20,7 @@ pub async fn make_payments(item: Json<PaymentTx>) -> HttpResponse {
     let ts = ToValidate {
         payment: pmt,
         received: Instant::now(),
+        timeout_block: None,
     };
     add_to_incoming_transaction_queue(ts);
 
@@ -36,6 +37,7 @@ pub async fn make_payments_v2(item: Json<HashSet<PaymentTx>>) -> HttpResponse {
         let ts = ToValidate {
             payment: pmt,
             received: Instant::now(),
+            timeout_block: None,
         };
         add_to_incoming_transaction_queue(ts);
     }

--- a/rita_common/src/network_endpoints/mod.rs
+++ b/rita_common/src/network_endpoints/mod.rs
@@ -1,9 +1,9 @@
 //! Network endptoints for common Rita functionality (such as exchanging hello messages)
 
-use crate::payment_validator::{validate_later, ToValidate};
+use crate::payment_validator::{add_to_incoming_transaction_queue, ToValidate};
 use crate::peer_listener::structs::Peer;
+use crate::tm_identity_callback;
 use crate::tunnel_manager::id_callback::IdentityCallback;
-use crate::{tm_identity_callback, RitaCommonError};
 
 use actix_web_async::http::StatusCode;
 use actix_web_async::web::Json;
@@ -20,40 +20,29 @@ pub async fn make_payments(item: Json<PaymentTx>) -> HttpResponse {
     let ts = ToValidate {
         payment: pmt,
         received: Instant::now(),
-        checked: false,
     };
+    add_to_incoming_transaction_queue(ts);
 
-    match validate_later(ts) {
-        Ok(()) | Err(RitaCommonError::DuplicatePayment) => {
-            HttpResponse::Ok().json("Payment Received!")
-        }
-        Err(e) => HttpResponse::build(StatusCode::from_u16(400u16).unwrap()).json(&format!("{e}")),
-    }
+    // we can't actually check validity here so we simply return Ok
+    // in any case it's not possible to return if the payment was invalid
+    // as we may find a validation condition only after making many other checks
+    HttpResponse::Ok().json("Payment Received!")
 }
 
 /// The recieve side of the make payments v2 call. This processes a list of payments instead of a single payment
 pub async fn make_payments_v2(item: Json<HashSet<PaymentTx>>) -> HttpResponse {
     let pmt_list = item.into_inner();
-    let mut build_err = String::new();
     for pmt in pmt_list {
         let ts = ToValidate {
             payment: pmt,
             received: Instant::now(),
-            checked: false,
         };
-
-        // Duplicates will be removed here
-        match validate_later(ts) {
-            Ok(()) | Err(RitaCommonError::DuplicatePayment) => {}
-            Err(e) => {
-                build_err.push_str(&format!("{e}\n"));
-            }
-        }
+        add_to_incoming_transaction_queue(ts);
     }
 
-    if !build_err.is_empty() {
-        return HttpResponse::build(StatusCode::from_u16(400u16).unwrap()).json(&build_err);
-    }
+    // we can't actually check validity here so we simply return Ok
+    // in any case it's not possible to return if the payment was invalid
+    // as we may find a validation condition only after making many other checks
     HttpResponse::Ok().json("Payment Received!")
 }
 

--- a/rita_common/src/rita_loop/fast_loop.rs
+++ b/rita_common/src/rita_loop/fast_loop.rs
@@ -3,7 +3,7 @@ use crate::debt_keeper::send_debt_update;
 use crate::network_monitor::update_network_info;
 use crate::network_monitor::NetworkInfo as NetworkMonitorTick;
 use crate::payment_controller::tick_payment_controller;
-use crate::payment_validator::validate;
+use crate::payment_validator::PaymentValidator;
 use crate::peer_listener::peerlistener_tick;
 use crate::peer_listener::structs::PeerListener;
 use crate::traffic_watcher::watch;
@@ -14,7 +14,6 @@ use actix_async::System as AsyncSystem;
 use babel_monitor::open_babel_stream;
 use babel_monitor::parse_neighs;
 use babel_monitor::parse_routes;
-
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -39,64 +38,70 @@ pub fn start_rita_fast_loop() {
         // this will always be an error, so it's really just a loop statement
         // with some fancy destructuring
         while let Err(e) = {
-            thread::spawn(move || loop {
+            thread::spawn(move || {
                 trace!("Common Fast tick!");
                 let start = Instant::now();
-
                 let runner = AsyncSystem::new();
+                let babel_port = settings::get_rita_common().network.babel_port;
+                let system_chain = settings::get_rita_common().payment.system_chain;
                 runner.block_on(async move {
-                    let babel_port = settings::get_rita_common().network.babel_port;
-                    trace!("Common tick!");
+                    let mut payment_validator_state = PaymentValidator::new();
+                    let mut outgoing_payments = Vec::new();
+                    loop {
+                        trace!("Common tick!");
 
-                    let res = tm_get_neighbors();
-                    trace!("Currently open tunnels: {:?}", res);
-                    let neighbors = res;
-                    let neigh = Instant::now();
+                        let res = tm_get_neighbors();
+                        trace!("Currently open tunnels: {:?}", res);
+                        let neighbors = res;
+                        let neigh = Instant::now();
 
-                    if let Ok(mut stream) = open_babel_stream(babel_port, FAST_LOOP_TIMEOUT) {
-                        if let Ok(babel_routes) = parse_routes(&mut stream) {
-                            if let Err(e) = watch(babel_routes.clone(), &neighbors) {
-                                error!("Error for Rita common traffic watcher {}", e);
-                            }
-                            info!(
-                                "TrafficWatcher completed in {}s {}ms",
-                                neigh.elapsed().as_secs(),
-                                neigh.elapsed().subsec_millis()
-                            );
+                        if let Ok(mut stream) = open_babel_stream(babel_port, FAST_LOOP_TIMEOUT) {
+                            if let Ok(babel_routes) = parse_routes(&mut stream) {
+                                if let Err(e) = watch(babel_routes.clone(), &neighbors) {
+                                    error!("Error for Rita common traffic watcher {}", e);
+                                }
+                                info!(
+                                    "TrafficWatcher completed in {}s {}ms",
+                                    neigh.elapsed().as_secs(),
+                                    neigh.elapsed().subsec_millis()
+                                );
 
-                            // Observe the dataplane for status and problems.
-                            if let Ok(babel_neighbors) = parse_neighs(&mut stream) {
-                                let rita_neighbors = tm_get_neighbors();
-                                trace!("Sending network monitor tick");
-                                update_network_info(NetworkMonitorTick {
-                                    babel_neighbors,
-                                    babel_routes,
-                                    rita_neighbors,
-                                });
+                                // Observe the dataplane for status and problems.
+                                if let Ok(babel_neighbors) = parse_neighs(&mut stream) {
+                                    let rita_neighbors = tm_get_neighbors();
+                                    trace!("Sending network monitor tick");
+                                    update_network_info(NetworkMonitorTick {
+                                        babel_neighbors,
+                                        babel_routes,
+                                        rita_neighbors,
+                                    });
+                                }
                             }
                         }
-                    }
 
-                    // Update debts
-                    if let Err(e) = send_debt_update() {
-                        warn!("Debt keeper update failed! {:?}", e);
-                    }
+                        // Update debts
+                        if let Err(e) = send_debt_update() {
+                            warn!("Debt keeper update failed! {:?}", e);
+                        }
 
-                    // updating blockchain info often is easier than dealing with edge cases
-                    // like out of date nonces or balances, also users really really want fast
-                    // balance updates, think very long and very hard before running this more slowly
-                    BlockchainOracleUpdate().await;
-                    info!("Finished oracle update!");
-                    // Check on payments, only really needs to be run this quickly
-                    // on large nodes where very high variation in throughput can result
-                    // in blowing through the entire grace in less than a minute
-                    validate().await;
-                    info!("Finished validated!");
-                    // Process payments queued for sending, needs to be run often for
-                    // the same reason as the validate code, during high throughput periods
-                    // payments must be sent quickly to avoid enforcement
-                    tick_payment_controller().await;
-                    info!("Finished tick payment controller!");
+                        // updating blockchain info often is easier than dealing with edge cases
+                        // like out of date nonces or balances, also users really really want fast
+                        // balance updates, think very long and very hard before running this more slowly
+                        BlockchainOracleUpdate().await;
+                        info!("Finished oracle update!");
+                        // Check on payments, only really needs to be run this quickly
+                        // on large nodes where very high variation in throughput can result
+                        // in blowing through the entire grace in less than a minute
+                        let previously_sent_payments = payment_validator_state
+                            .tick_payment_validator(outgoing_payments, system_chain)
+                            .await;
+                        info!("Finished validated!");
+                        // Process payments queued for sending, needs to be run often for
+                        // the same reason as the validate code, during high throughput periods
+                        // payments must be sent quickly to avoid enforcement
+                        outgoing_payments = tick_payment_controller(previously_sent_payments).await;
+                        info!("Finished tick payment controller!");
+                    }
                 });
                 info!(
                     "Common Fast tick completed in {}s {}ms",

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -3,7 +3,7 @@ use crate::logging::LoggingSettings;
 use crate::network::NetworkSettings;
 use crate::operator::OperatorSettings;
 use crate::payment::PaymentSettings;
-use crate::{json_merge, set_rita_client, setup_accepted_denoms, SettingsError};
+use crate::{json_merge, set_rita_client, SettingsError};
 use althea_types::{ContactStorage, ExitState, Identity};
 
 use std::collections::{HashMap, HashSet};
@@ -160,11 +160,7 @@ impl RitaClientSettings {
         }
 
         let config_toml = std::fs::read_to_string(file_name)?;
-        let mut ret: Self = toml::from_str(&config_toml)?;
-
-        // Setup accepted denoms for payment validator, this is for routers during opkg updates,
-        // this can be removed once all router are updated to the version that handles althea chain
-        ret.payment.accepted_denoms = Some(setup_accepted_denoms());
+        let ret: Self = toml::from_str(&config_toml)?;
 
         set_rita_client(ret.clone());
 

--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -1,7 +1,7 @@
 use crate::localization::LocalizationSettings;
 use crate::network::NetworkSettings;
 use crate::payment::PaymentSettings;
-use crate::{json_merge, set_rita_exit, setup_accepted_denoms, SettingsError};
+use crate::{json_merge, set_rita_exit, SettingsError};
 use althea_types::{regions::Regions, ExitIdentity, FromStr, Identity, WgKey};
 use clarity::Address;
 use ipnetwork::IpNetwork;
@@ -259,11 +259,7 @@ impl RitaExitSettingsStruct {
         }
 
         let config_toml = std::fs::read_to_string(file_name)?;
-        let mut ret: Self = toml::from_str(&config_toml)?;
-
-        // Setup accepted denoms for payment validator, this is for routers during opkg updates,
-        // this can be removed once all router are updated to the version that handles althea chain
-        ret.payment.accepted_denoms = Some(setup_accepted_denoms());
+        let ret: Self = toml::from_str(&config_toml)?;
 
         set_rita_exit(ret.clone());
 

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -18,7 +18,7 @@ extern crate log;
 extern crate arrayvec;
 
 use althea_kernel_interface::KI;
-use althea_types::{Denom, Identity};
+use althea_types::Identity;
 use network::NetworkSettings;
 use payment::PaymentSettings;
 use serde::Serialize;
@@ -160,18 +160,6 @@ pub fn write_config() -> Result<(), SettingsError> {
         }
         None => panic!("expected settings but got none"),
     }
-}
-
-/// Sets up default accepts denoms, by default we need to add the debt keeper denom
-/// As we add more accepted denoms, they will be added during bridge of funds
-pub fn setup_accepted_denoms() -> HashMap<String, Denom> {
-    let mut map = HashMap::new();
-    let wei = Denom {
-        denom: DEBT_KEEPER_DENOM.to_string(),
-        decimal: DEBT_KEEPER_DENOM_DECIMAL,
-    };
-    map.insert("xdai".to_string(), wei);
-    map
 }
 
 /// On an interupt (SIGTERM), saving settings before exiting

--- a/settings/src/payment.rs
+++ b/settings/src/payment.rs
@@ -5,7 +5,6 @@ use auto_bridge::TokenBridgeAddresses;
 use clarity::{Address, PrivateKey};
 use num256::Int256;
 use num256::Uint256;
-use std::collections::HashMap;
 
 fn default_max_fee() -> u32 {
     200_000_000u32 // denominated in wei/byte
@@ -113,8 +112,14 @@ pub struct PaymentSettings {
     pub eth_private_key: Option<PrivateKey>,
     /// Our own eth Address, derived from the private key on startup and not stored
     pub eth_address: Option<Address>,
-    /// Payment denoms that payment validator accepts. Ex usdc -> Denom {ibc/hash, 1_000_000}
-    pub accepted_denoms: Option<HashMap<String, Denom>>,
+    /// Payment denoms that payment validator accepts on Althea L1. Ex usdc -> Denom {ibc/hash, 1_000_000}
+    /// the nubmer is the multiplier to convert one unit of this denom to $1 since these are all
+    /// assumed to be stable coins
+    #[serde(default)]
+    pub althea_l1_accepted_denoms: Vec<Denom>,
+    /// By default when this node makes a payment it will use this denom
+    #[serde(default = "default_althea_l1_payment_denom")]
+    pub althea_l1_payment_denom: Denom,
     /// GRPC Node used to create a contact object to interact with althea blockchain
     #[serde(default = "default_node_grpc")]
     pub althea_grpc_list: Vec<String>,
@@ -166,6 +171,15 @@ pub struct PaymentSettings {
     pub min_gas: Uint256,
 }
 
+/// TODO this is currently a testnet only placeholder it should be replaced
+/// with a real IBC denom post Althea L1 launch
+fn default_althea_l1_payment_denom() -> Denom {
+    Denom {
+        denom: "uUSDC".to_string(),
+        decimal: 1_000_000u64,
+    }
+}
+
 impl Default for PaymentSettings {
     fn default() -> Self {
         PaymentSettings {
@@ -175,7 +189,6 @@ impl Default for PaymentSettings {
             client_can_use_free_tier: default_client_can_use_free_tier(),
             balance_warning_level: default_balance_warning_level(),
             payment_threshold: default_payment_threshold(),
-            accepted_denoms: None,
             enable_enforcement: true,
             eth_private_key: None,
             eth_address: None,
@@ -192,6 +205,8 @@ impl Default for PaymentSettings {
             simulated_transaction_fee: default_simulated_transaction_fee(),
             forgive_on_reboot: default_forgive_on_reboot(),
             min_gas: default_min_gas(),
+            althea_l1_accepted_denoms: vec![default_althea_l1_payment_denom()],
+            althea_l1_payment_denom: default_althea_l1_payment_denom(),
         }
     }
 }


### PR DESCRIPTION
This patch contains a significant number of changes to payment validator and in fact a complete re-design of how it moves information around, although the core logic itself remains the same.

Instead of having payment validator state stored in a lazy static and then accessed by a lock from various places, it's now stored in a single scope, the rita fast loop.

This dramatically simplifies the way information flows through the program, prviously when a payment was made by payment controller the entire state of payment validator was accessed via a lock and updated, now that data is simply passed as a function argument.

The one case where cross thread interaction is required is passing information from the actix endpoints into the rita client thread. Instead of using a lock over all of the payment validator state this has now been replaced with a lock free queue that payment validator dequeues from during validation.

This did require two changes to how Rita behaves.

Payments that are not yet validated are no longer included in the rita exit debts endpoint. We made that change to prevent clients from paying the exit twice if it was running slowly. The lock free changes make this slow operation much less probable and also repeated payments are a symptom of the low timeout bug we have just recently encountered and fixed.

Second when a client sent in a transaction that was a duplicate we would return an error, we no longer do so. Instead we return ok and drop the tx as a duplicate later.

Both of these changes required access to the entire program state in random other threads and contributed to slower operation and deadlocks.

Ideally I'd like this to be the model for how to refactor other Rita modules going forward. There's a lot of cruft still left over from the original Actix actors structure, which we essentially replicated as closely as possible when moving to individual threads in Async await.

Now we have to do the second part of that refinement.

As a final note Althea paymetns have been modified to expect a MsgMicroTX and payment_controller needs to be updated to send one.