### PR TITLE
Bump nofiles limit in tests

### DIFF
--- a/rita_client_registration/src/client_db.rs
+++ b/rita_client_registration/src/client_db.rs
@@ -343,7 +343,7 @@ pub fn parse_identity_abi(byte_chunks: Vec<Vec<u8>>) -> Result<Identity, Web3Err
     });
 
     if mesh_ip == 0 {
-        error!("Received a null entry! {:?}", byte_chunks);
+        warn!("Received a null entry! {:?}", byte_chunks);
         return Err(Web3Error::BadInput(format!(
             "Recived a null output {byte_chunks:?}."
         )));

--- a/scripts/integration_tests/all-up-test.sh
+++ b/scripts/integration_tests/all-up-test.sh
@@ -28,4 +28,4 @@ set +u
 TEST_TYPE=$1
 set -u
 
-docker run --name $CONTAINER_NAME-all-up --privileged -t $CONTAINER_NAME /bin/bash /althea_rs/scripts/integration_tests/container_scripts/all-up-test-internal.sh $NODES $TEST_TYPE
+docker run --ulimit nofile=262144:262144 --name $CONTAINER_NAME-all-up --privileged -t $CONTAINER_NAME /bin/bash /althea_rs/scripts/integration_tests/container_scripts/all-up-test-internal.sh $NODES $TEST_TYPE

--- a/scripts/integration_tests/start-chains.sh
+++ b/scripts/integration_tests/start-chains.sh
@@ -17,4 +17,4 @@ NODES=3
 pushd $DIR/../
 
 # Run new test container instance
-docker run --name $CONTAINER_NAME-instance --mount type=bind,source="$DIR/../../",target=/althea_rs --privileged -p 2345:2345 -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it $CONTAINER_NAME /bin/bash /althea_rs/scripts/integration_tests/container_scripts/reload-code.sh $NODES
+docker run --ulimit nofile=262144:262144 --name $CONTAINER_NAME-instance --mount type=bind,source="$DIR/../../",target=/althea_rs --privileged -p 2345:2345 -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it $CONTAINER_NAME /bin/bash /althea_rs/scripts/integration_tests/container_scripts/reload-code.sh $NODES


### PR DESCRIPTION
With the several blockchain nodes combined with several rita nodes these tests reliably run into file limits. Hopefully bumping this limit will increase reliability in CI as well as locally.