### PR TITLE
Use the to string representation for SystemChain parsing

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -9,6 +9,7 @@ use deep_space::Address as AltheaAddress;
 use ipnetwork::IpNetwork;
 use num256::Uint256;
 use serde::de::Error;
+use serde::Serialize;
 use serde::{Deserialize, Deserializer, Serializer};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
@@ -152,7 +153,7 @@ pub struct Denom {
     pub decimal: u64,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, Copy)]
+#[derive(Default, Debug, Hash, Clone, Eq, PartialEq, Copy)]
 pub enum SystemChain {
     Ethereum,
     Sepolia,
@@ -190,7 +191,7 @@ impl Display for SystemChain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SystemChain::Ethereum => write!(f, "Ethereum"),
-            SystemChain::Sepolia => write!(f, "Rinkeby"),
+            SystemChain::Sepolia => write!(f, "Sepolia"),
             SystemChain::Xdai => write!(f, "Xdai"),
             SystemChain::AltheaL1 => write!(f, "Althea"),
         }
@@ -202,27 +203,54 @@ fn default_system_chain() -> SystemChain {
 }
 
 impl FromStr for SystemChain {
-    type Err = ();
-    fn from_str(s: &str) -> Result<SystemChain, ()> {
+    type Err = String;
+    fn from_str(s: &str) -> Result<SystemChain, String> {
         match s {
             "Ethereum" => Ok(SystemChain::Ethereum),
+            "ethereum" => Ok(SystemChain::Ethereum),
+            "eth" => Ok(SystemChain::Ethereum),
+            "ETH" => Ok(SystemChain::Ethereum),
             "Rinkeby" => Ok(SystemChain::Sepolia),
+            "rinkeby" => Ok(SystemChain::Sepolia),
             "Sepolia" => Ok(SystemChain::Sepolia),
+            "sepolia" => Ok(SystemChain::Sepolia),
             "Testnet" => Ok(SystemChain::Sepolia),
             "Test" => Ok(SystemChain::Sepolia),
+            "testnet" => Ok(SystemChain::Sepolia),
+            "test" => Ok(SystemChain::Sepolia),
             "Xdai" => Ok(SystemChain::Xdai),
+            "xDai" => Ok(SystemChain::Xdai),
+            "xDAI" => Ok(SystemChain::Xdai),
             "xdai" => Ok(SystemChain::Xdai),
-            "gnosis" => Ok(SystemChain::Xdai),
-            "gnosischain" => Ok(SystemChain::Xdai),
-            "Althea" => Ok(SystemChain::AltheaL1),
-            "althea" => Ok(SystemChain::AltheaL1),
-            "altheachain" => Ok(SystemChain::AltheaL1),
             "GnosisChain" => Ok(SystemChain::Xdai),
+            "gnosischain" => Ok(SystemChain::Xdai),
             "Gnosis" => Ok(SystemChain::Xdai),
+            "gnosis" => Ok(SystemChain::Xdai),
+            "Althea" => Ok(SystemChain::AltheaL1),
             "AltheaL1" => Ok(SystemChain::AltheaL1),
             "altheal1" => Ok(SystemChain::AltheaL1),
-            _ => Err(()),
+            "altheaL1" => Ok(SystemChain::AltheaL1),
+            _ => Err("Unknown SystemChain!".to_string()),
         }
+    }
+}
+
+impl Serialize for SystemChain {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SystemChain {
+    fn deserialize<D>(deserializer: D) -> Result<SystemChain, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -338,7 +338,7 @@ mod tests {
         let mut history = HashSet::new();
         for _ in 0..1000 {
             let ip = generate_mesh_ip().unwrap();
-            if history.get(&ip).is_some() {
+            if history.contains(&ip) {
                 panic!("Got duplicate ip {}", ip)
             } else {
                 history.insert(ip);

--- a/rita_client/src/dashboard/system_chain.rs
+++ b/rita_client/src/dashboard/system_chain.rs
@@ -8,7 +8,7 @@ use settings::payment::PaymentSettings;
 /// Changes the full node configuration value between test/prod and other networks
 pub async fn set_system_blockchain_endpoint(path: Path<String>) -> HttpResponse {
     info!("Blockchain change endpoint hit!");
-    let id: Result<SystemChain, ()> = path.into_inner().parse();
+    let id: Result<SystemChain, _> = path.into_inner().parse();
     if id.is_err() {
         return HttpResponse::build(StatusCode::BAD_REQUEST)
             .json(format!("Could not parse {id:?} into a SystemChain enum!"));

--- a/rita_common/src/traffic_watcher/mod.rs
+++ b/rita_common/src/traffic_watcher/mod.rs
@@ -364,6 +364,6 @@ mod tests {
         assert_eq!(ip_a, ip_b);
         let mut map = HashMap::new();
         map.insert(ip_b, "test");
-        assert!(map.get(&ip_a).is_some());
+        assert!(map.contains_key(&ip_a));
     }
 }

--- a/rita_common/src/tunnel_manager/mod.rs
+++ b/rita_common/src/tunnel_manager/mod.rs
@@ -682,7 +682,7 @@ pub mod tests {
                 .unwrap(),
             None,
         );
-        assert!(tunnel_manager.tunnels.get(&id).is_none());
+        assert!(!tunnel_manager.tunnels.contains_key(&id));
 
         // Create dummy tunnel
         tunnel_manager


### PR DESCRIPTION
This helps solve an upgrade path where we find an old variant or an different name in the system chain field. By parsing through our to/from string implementation we can ensure that the values are synced and accept a variety of different inputs.