### PR TITLE
Don't mark payment as failed when we get a json_rpc error

### DIFF
--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -28,7 +28,6 @@ use std::fmt::{Display, Formatter};
 use std::time::Duration;
 use std::time::Instant;
 use web30::client::Web3;
-use web30::jsonrpc::error::Web3Error;
 
 pub const TRANSACTION_SUBMISSION_TIMEOUT: Duration = Duration::from_secs(15);
 pub const MAX_TXID_RETRIES: u8 = 15u8;
@@ -390,15 +389,8 @@ async fn make_xdai_payment(
                     );
                     // it is now possible that this transaction has been published
                     // so we have to try and determine what happened
-                    if let Web3Error::JsonRpcError { .. } = e {
-                        // in this case, we got a response from the full node that it did not like our
-                        // tx, no chance that it is published (unless they start lying to us in a new way)
-                        payment_failed(pmt.to);
-                        return Err(PaymentControllerError::FailedToSendPayment);
-                    } else {
-                        // the published state of the tx is ambiguous, now we have to pretend like we sent it.
-                        tx.txid()
-                    }
+                    // the published state of the tx is ambiguous, now we have to pretend like we sent it.
+                    tx.txid()
                 }
             };
 


### PR DESCRIPTION
This patch resolves an issue where routers may repeatedly overpay because of a temporary full node error. The original goal of this bit of logic was to fail the payment fast if the error was from the json_rpc (transaction failed validation) but json rpc errors can actually encompass more types of failures including some where the rpc node actually did send the tx.

Now we fall back to just always believeing we have sent the tx in this case and verifying via the txid.

Also modified here is the behavior around blocking tx when payment issues are detected, since the timeout is triggered internally when the MakePayment state machine result is returned blocking a payemnt in this case only results in a 10 minute timeout and never any positive result.

This patch also adds some extra logging to failure cases and renames the debt keeper send update function to be more intitutive to read.