### PR TITLE
Fix is_gateway() check being true for LTE clients

### DIFF
--- a/rita_client/src/rita_loop/mod.rs
+++ b/rita_client/src/rita_loop/mod.rs
@@ -26,7 +26,6 @@ use althea_types::ExitState;
 use antenna_forwarding_client::start_antenna_forwarding_proxy;
 use rita_common::dashboard::interfaces::get_interfaces;
 use rita_common::dashboard::interfaces::InterfaceMode;
-use rita_common::rita_loop::set_gateway;
 use rita_common::tunnel_manager::tm_get_neighbors;
 use rita_common::usage_tracker::get_current_hour;
 use rita_common::usage_tracker::get_last_saved_usage_hour;
@@ -248,10 +247,6 @@ fn manage_gateway() {
     if let Some(external_nic) = settings::get_rita_common().network.external_nic {
         if is_iface_up(&external_nic).unwrap_or(false) {
             if let Ok(interfaces) = get_interfaces() {
-                info!("We are a Gateway");
-                // this flag is used to handle billing around the corner case
-                set_gateway(true);
-
                 // This is used to insert a route for each dns server in /etc/resolv.conf to override
                 // the wg_exit default route, this is needed for bootstrapping as a gateway can not
                 // resolve the exit ip addresses in order to perform peer discovery without these rules

--- a/rita_common/src/rita_loop/mod.rs
+++ b/rita_common/src/rita_loop/mod.rs
@@ -5,36 +5,40 @@
 //! all system functions. Anything that blocks will eventually filter up to block this loop and
 //! halt essential functions like opening tunnels and managing peers
 
+use crate::dashboard::interfaces::get_interfaces;
+use crate::dashboard::interfaces::InterfaceMode;
 use crate::network_endpoints::*;
 use crate::traffic_watcher::init_traffic_watcher;
 use actix::System;
 use actix_web::{web, App, HttpServer};
+use althea_kernel_interface::ip_addr::is_iface_up;
 use rand::thread_rng;
 use rand::Rng;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use std::thread;
 
 pub mod fast_loop;
 pub mod slow_loop;
 pub mod write_to_disk;
 
-lazy_static! {
-    /// keeps track of if this node is a gateway, specifically if this node
-    /// needs to perform the various edge case behaviors required to manage
-    /// peering out to exits over a WAN port. This includes DHCP lookups
-    /// in tunnel manager, where the gateway reaches out to it's manual peers
-    /// to create NAT punching tunnels to the exit and setting routes to prevent
-    /// exit traffic from going over the exit tunnel (which obviously doesn't work)
-    static ref IS_GATEWAY: AtomicBool = AtomicBool::new(false);
-}
-
+/// returns true if this node is a gateway, specifically if this node
+/// needs to perform the various edge case behaviors required to manage
+/// peering out to exits over a WAN port. This includes DHCP lookups
+/// in tunnel manager, where the gateway reaches out to it's manual peers
+/// to create NAT punching tunnels to the exit and setting routes to prevent
+/// exit traffic from going over the exit tunnel (which obviously doesn't work)
 pub fn is_gateway() -> bool {
-    IS_GATEWAY.load(Ordering::Relaxed)
-}
-
-pub fn set_gateway(input: bool) {
-    IS_GATEWAY.store(input, Ordering::Relaxed)
+    if let Some(external_nic) = settings::get_rita_common().network.external_nic {
+        if is_iface_up(&external_nic).unwrap_or(false) {
+            if let Ok(interfaces) = get_interfaces() {
+                if let Some(mode) = interfaces.get(&external_nic) {
+                    if matches!(mode, InterfaceMode::Wan | InterfaceMode::StaticWan { .. }) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Checks the list of full nodes, panics if none exist, if there exist


### PR DESCRIPTION
This is both a cleanup and a logic fix. LTE clients should not mark themselves as gateways, this could have been fixed just by moving the set_gateway() statement into the interface mode check.

But thanks to recent movements of the interface code it's now possible to simply drop the lazy static itself. Performance wise this function isn't called enough, nor is it complex enough to warrant serious concern about have to execute the check each time instead of simply loading the cached version.