### PR TITLE
Fix missing wifi device data

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -92,6 +92,7 @@ pub enum KernelInterfaceError {
     FailedToGetSystemTime,
     FailedToGetSystemKernelVersion,
     ParseError(String),
+    FromUtf8Error,
 }
 
 impl fmt::Display for KernelInterfaceError {
@@ -134,6 +135,7 @@ impl fmt::Display for KernelInterfaceError {
             KernelInterfaceError::FailedToGetSystemKernelVersion => {
                 write!(f, "Failed to get system kernel version!")
             }
+            KernelInterfaceError::FromUtf8Error => write!(f, "Could not parse from utf8 output"),
         }
     }
 }


### PR DESCRIPTION
Getting wifi iface names from 'uci show wireless' is no longer an option since these do not always get saved to config- and routers that were missing hard coded ifname config were not populating wifi devices to report to ops. Instead, 'iw dev' lists all interfaces for wifi and those ifnames can be more reliably accessed from there.