### PR TITLE
Fix multi exit test, refactor registration state data flow

### DIFF
--- a/althea_types/src/exits/mod.rs
+++ b/althea_types/src/exits/mod.rs
@@ -52,6 +52,16 @@ pub enum ExitState {
 }
 
 impl ExitState {
+    pub fn get_exit_mesh_ip(&self) -> Option<IpAddr> {
+        match *self {
+            ExitState::Registered {
+                ref general_details,
+                ..
+            } => Some(general_details.server_internal_ip),
+            _ => None,
+        }
+    }
+
     pub fn general_details(&self) -> Option<&ExitDetails> {
         match *self {
             ExitState::Registered {

--- a/integration_tests/src/mutli_exit.rs
+++ b/integration_tests/src/mutli_exit.rs
@@ -74,9 +74,6 @@ pub async fn run_multi_exit_test() {
 
     test_routes(namespaces.clone(), expected_routes);
 
-    // sleep so that the exit manager loop can grab the verified exits from the servers (required before registering)
-    thread::sleep(Duration::from_secs(10));
-
     info!("Registering routers to the exit");
     register_all_namespaces_to_exit(namespaces.clone()).await;
 

--- a/integration_tests/src/setup_utils/rita.rs
+++ b/integration_tests/src/setup_utils/rita.rs
@@ -191,12 +191,12 @@ pub fn spawn_rita(
         let system = actix::System::new();
 
         start_rita_common_loops();
-        start_rita_client_loops();
+        let em_state = start_rita_client_loops();
         save_to_disk_loop(SettingsOnDisk::RitaClientSettings(Box::new(
             settings::get_rita_client(),
         )));
         start_core_rita_endpoints(1);
-        start_client_dashboard(s.network.rita_dashboard_port);
+        start_client_dashboard(s.network.rita_dashboard_port, em_state);
 
         if let Err(e) = system.run() {
             panic!("Starting client failed with {}", e);

--- a/integration_tests/src/utils.rs
+++ b/integration_tests/src/utils.rs
@@ -336,17 +336,19 @@ pub fn test_all_internet_connectivity(namespaces: NamespaceInfo) {
                 ],
             )
             .unwrap();
-            if String::from_utf8(out.stdout)
-                .unwrap()
-                .contains("1 received")
-            {
+            let output_string = from_utf8(&out.stdout).unwrap();
+            if output_string.contains("1 received") {
                 info!("Ping test passed for {}!", ns.get_name());
                 break;
             } else {
                 if Instant::now() - start > Duration::from_secs(60) {
                     panic!("{} does not have internet connectivity", ns.get_name());
                 }
-                error!("Ping failed for {}, trying again", ns.get_name());
+                error!(
+                    "Ping failed for {} with {}, trying again",
+                    ns.get_name(),
+                    output_string
+                );
                 thread::sleep(Duration::from_secs(5));
             }
         }

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -176,12 +176,12 @@ fn main() {
     let system = actix::System::new();
 
     start_rita_common_loops();
-    start_rita_client_loops();
+    let em_ref = start_rita_client_loops();
     save_to_disk_loop(SettingsOnDisk::RitaClientSettings(Box::new(
         settings::get_rita_client(),
     )));
     start_core_rita_endpoints(4);
-    start_client_dashboard(settings.network.rita_dashboard_port);
+    start_client_dashboard(settings.network.rita_dashboard_port, em_ref);
     start_antenna_forwarder(settings);
 
     // utility and rescue fucntions, these perform some upgrade or check

--- a/rita_client/src/exit_manager/utils.rs
+++ b/rita_client/src/exit_manager/utils.rs
@@ -1,5 +1,4 @@
 use super::LastExitStates;
-use crate::heartbeat::get_exit_registration_state;
 use crate::rita_loop::CLIENT_LOOP_TIMEOUT;
 use crate::RitaClientError;
 use actix_web::Result;
@@ -40,7 +39,7 @@ pub fn linux_setup_exit_tunnel(
         return Err(RitaClientError::MiscStringError(v));
     }
 
-    error!(
+    info!(
         "Got wg exit listen port as: {}",
         selected_exit.wg_exit_listen_port
     );
@@ -88,8 +87,7 @@ pub fn correct_default_route(input: Option<DefaultRoute>) -> bool {
     }
 }
 
-pub fn get_client_pub_ipv6() -> Option<IpNetwork> {
-    let exit_info = get_exit_registration_state();
+pub fn get_client_pub_ipv6(exit_info: ExitState) -> Option<IpNetwork> {
     if let ExitState::Registered { our_details, .. } = exit_info {
         return our_details.internet_ipv6_subnet;
     }

--- a/rita_exit/src/database/dualmap.rs
+++ b/rita_exit/src/database/dualmap.rs
@@ -164,4 +164,24 @@ mod tests {
         assert_eq!(map.get_by_value(&"a"), None);
         assert_eq!(map.get_by_value(&"b"), None);
     }
+
+    #[test]
+    fn test_get_by_key() {
+        let mut map = DualMap::new();
+        map.insert(1, "a");
+        map.insert(2, "b");
+        assert_eq!(map.get_by_key(&1), Some(&"a"));
+        assert_eq!(map.get_by_key(&2), Some(&"b"));
+        assert_eq!(map.get_by_key(&3), None);
+    }
+
+    #[test]
+    fn test_get_by_value() {
+        let mut map = DualMap::new();
+        map.insert(1, "a");
+        map.insert(2, "b");
+        assert_eq!(map.get_by_value(&"a"), Some(&1));
+        assert_eq!(map.get_by_value(&"b"), Some(&2));
+        assert_eq!(map.get_by_value(&"c"), None);
+    }
 }

--- a/rita_exit/src/database/ipddr_assignment.rs
+++ b/rita_exit/src/database/ipddr_assignment.rs
@@ -241,6 +241,11 @@ impl ClientListAnIpAssignmentMap {
     ) -> Result<Ipv4Addr, Box<RitaExitError>> {
         // check if we have already assigned an ip to this client
         if let Some(val) = self.internal_ip_assignments.get_by_value(&their_record) {
+            trace!(
+                "ip already assigned, returning {} for {}",
+                val,
+                their_record.wg_public_key
+            );
             return Ok(*val);
         }
 
@@ -260,6 +265,7 @@ impl ClientListAnIpAssignmentMap {
                         .internal_subnet
                         .broadcast()
             {
+                trace!("Assigned {} internal ip {}", their_record.wg_public_key, ip);
                 self.internal_ip_assignments.insert(ip, their_record);
                 return Ok(ip);
             }

--- a/rita_exit/src/traffic_watcher/mod.rs
+++ b/rita_exit/src/traffic_watcher/mod.rs
@@ -196,7 +196,7 @@ pub fn watch_exit_traffic(
     // creates new usage entires does not actualy update the values
     prepare_usage_history(&counters, usage_history);
 
-    counters_logging(&counters, &usage_history, our_price as u32);
+    counters_logging(&counters, usage_history, our_price as u32);
 
     // accounting for 'input'
     for (wg_key, bytes) in counters.clone() {

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -4,7 +4,7 @@ use crate::operator::OperatorSettings;
 use crate::payment::PaymentSettings;
 use crate::{json_merge, set_rita_client, SettingsError};
 use althea_types::regions::Regions;
-use althea_types::{ExitServerList, ExitState, Identity};
+use althea_types::{ExitServerList, Identity};
 use clarity::Address;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -27,10 +27,6 @@ fn exit_db_smart_contract() -> Address {
         .unwrap()
 }
 
-fn default_registration_state() -> ExitState {
-    ExitState::default()
-}
-
 /// This struct is used by rita to encapsulate all the state/information needed to connect/register
 /// to a exit and to setup the exit tunnel
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -40,11 +36,6 @@ pub struct ExitClientSettings {
     /// exit database smart contract. Once registered and online this list may be populated with new exits through the
     /// exit manager loop which receives verifiable exit lists.
     pub verified_exit_list: Option<ExitServerList>,
-    /// The registration state of this router with the exit database smart contract
-    /// note this value may be affected by what contract is currently selected and what
-    /// chain we are on. Since different chains may reference different registration smart contracts
-    #[serde(default = "default_registration_state", flatten)]
-    pub registration_state: ExitState,
     /// This is the address of the exit database contract, this value is a config value in case
     /// a new version of the contract is ever deployed. Otherwise it won't change much. What this contract contains
     /// is the registration data for all routers, facilitating key exchange between new exits in the cluster and clients
@@ -65,7 +56,6 @@ pub struct ExitClientSettings {
 impl Default for ExitClientSettings {
     fn default() -> Self {
         ExitClientSettings {
-            registration_state: default_registration_state(),
             exit_db_smart_contract: exit_db_smart_contract(),
             lan_nics: HashSet::new(),
             our_region: None,

--- a/test_runner/src/main.rs
+++ b/test_runner/src/main.rs
@@ -29,6 +29,7 @@ async fn main() {
     env_logger::Builder::default()
         .filter(None, log::LevelFilter::Error)
         .filter(Some("integration_tests"), log::LevelFilter::Info)
+        .filter(Some("rita_client::exit_manager"), log::LevelFilter::Info)
         .filter(Some("rita_exit"), log::LevelFilter::Info)
         .filter(Some("exit_trust_root"), log::LevelFilter::Info)
         .init();


### PR DESCRIPTION
This patch fixes the multi-exit test which has been broken since the patch "Simplify internal and ipv6 assignment". This is becuase that pr stopped using the fixed internal ip assignment code, where the same client would be deterministically assigned the same ip across multiple exit instances.

This sort of id hash based assignment brought in more complexity than it was worth. But removing it revealed that the exit details struct shouldn't be left as a single item. After all our exit details including the default route and our own ip can change between exits.

Including in this patch is an extensive re-write of the dataflow for the exit registration state, this is to move that state out of the config and avoid using a lazy-static to share it across threads. This modified state is more contained, and cleaner, although I would hesitate to call it clean since we sitll have some duplicated data in the exit manager state.

Moving the exit state out of settings (and in fact any thing that may change frequently) is very important becuase the settings lazy static has a copy -> modify -> write structure without a lock, data inconsistency is possible, and unavoidable for anything that changes quickly like exit states now will.