### PR TITLE
Fix AltheaDB Deploy script for manual deploys

### DIFF
--- a/solidity/contract-deployer.ts
+++ b/solidity/contract-deployer.ts
@@ -53,6 +53,7 @@ async function deploy() {
 
   const alt_location_2_altheadb = "AltheaDB.json"
 
+  const alt_location_3_altheadb = "artifacts/contracts/AltheaDB.sol/AltheaDB.json"
 
   if (fs.existsSync(main_location_altheadb)) {
     althea_db_path = main_location_altheadb
@@ -60,6 +61,8 @@ async function deploy() {
     althea_db_path = alt_location_1_altheadb
   } else if (fs.existsSync(alt_location_2_altheadb)) {
     althea_db_path = alt_location_2_altheadb
+  } else if (fs.existsSync(alt_location_3_altheadb)) {
+    althea_db_path = alt_location_3_altheadb
   } else {
     console.log("Test mode was enabled but the ERC20 contracts can't be found!")
     exit(1)

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -13820,7 +13820,6 @@
     },
     "node_modules/ganache-core/node_modules/keccak": {
       "version": "3.0.1",
-      "dev": true,
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
@@ -14393,7 +14392,6 @@
     },
     "node_modules/ganache-core/node_modules/node-addon-api": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -14407,7 +14405,6 @@
     },
     "node_modules/ganache-core/node_modules/node-gyp-build": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -38024,7 +38021,6 @@
         "keccak": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
@@ -38454,8 +38450,7 @@
         },
         "node-addon-api": {
           "version": "2.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -38463,8 +38458,7 @@
         },
         "node-gyp-build": {
           "version": "4.2.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "normalize-url": {
           "version": "4.5.0",


### PR DESCRIPTION
It was impossible to deploy from the solidity directory, adding a new alt location has fixed the issue